### PR TITLE
README: update Slack channel to #team-genai-top-10-llm

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The first version of this list was contributed by Steve Wilson of Contrast Secur
 
 For contributors working on the **2026 cycle**, see the track-specific guide in [`2026/CONTRIBUTING.md`](./2026/CONTRIBUTING.md).
 
-We have a working group channel on the [OWASP Slack](https://owasp.org/slack/invite), so please sign up and then join us on the #project-top10-llm channel.
+We have a working group channel on the [OWASP Slack](https://owasp.org/slack/invite), so please sign up and then join us on the #team-genai-top-10-llm channel.
 
 **Learn how to contribute:** [https://genai.owasp.org/contribute/](https://genai.owasp.org/contribute/)
 


### PR DESCRIPTION
## Summary
- Updates the Slack channel reference in the root README from `#project-top10-llm` to `#team-genai-top-10-llm` to reflect the renamed OWASP Slack channel.

## Test plan
- [x] `grep` confirms no other occurrences of the old channel name in the repo
- [ ] `npx markdownlint-cli2 "**/*.md"` passes in CI