### PR TITLE
CI: add entry conformance check + commit existing markdown-lint workflow

### DIFF
--- a/.github/scripts/check-entry-conformance.py
+++ b/.github/scripts/check-entry-conformance.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""
+Conformance checker for OWASP Top 10 for LLM Applications entries.
+
+Validates files against the rules in:
+- documentation/style/entries.md
+- 2026/_template.md (the canonical scaffold)
+
+Used by .github/workflows/entry-conformance.yml on pull_request events.
+Can also be run locally before pushing:
+
+    python .github/scripts/check-entry-conformance.py 2026/LLM01_PromptInjection.md
+
+Exit code: 0 = pass, 1 = at least one error.
+
+For each error, prints a GitHub Actions annotation:
+    ::error file=<path>,line=<n>::<message>
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REQUIRED_SECTIONS = [
+    "Description",
+    "Common Examples of Risk",
+    "Prevention and Mitigation Strategies",
+    "Example Attack Scenarios",
+    "Reference Links",
+]
+
+# Common British spellings to flag. Not exhaustive; add as needed.
+BRITISH_WORDS = [
+    "behaviour", "behaviours",
+    "colour", "colours", "coloured", "colouring",
+    "organisation", "organisations", "organisational",
+    "authorise", "authorised", "authorising", "authorisation",
+    "optimise", "optimised", "optimising", "optimisation",
+    "recognise", "recognised", "recognising",
+    "analyse", "analysed", "analysing",
+    "realise", "realised", "realising",
+    "centre", "centres", "centred",
+    "favourite", "favourites",
+    "licence",  # "license" is the US verb+noun
+]
+
+
+def annotate(path: Path, line: int, message: str) -> None:
+    """Emit a GitHub Actions error annotation."""
+    escaped = (
+        message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    )
+    print(f"::error file={path},line={line}::{escaped}")
+
+
+def file_kind(path: Path) -> str:
+    """Classify a file as 'track-b', 'track-a', 'template', or 'unknown'."""
+    s = str(path).replace("\\", "/")
+    if re.search(r"2026/LLM(0[1-9]|10)_[A-Za-z]+\.md$", s):
+        return "track-b"
+    if re.search(r"2026/new_entry_candidates/[^/]+\.md$", s):
+        return "track-a"
+    if s.endswith("2026/_template.md"):
+        return "template"
+    return "unknown"
+
+
+def parse_headings(text: str) -> list[tuple[int, int, str]]:
+    """Return [(line_no, level, title), ...] for ATX headings."""
+    out: list[tuple[int, int, str]] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        m = re.match(r"^(#{1,6})\s+(.+?)\s*$", line)
+        if m:
+            out.append((i, len(m.group(1)), m.group(2)))
+    return out
+
+
+def check_track_b(path: Path, text: str, errors: list) -> None:
+    """Validate a Track B (LLMXX_*.md) entry."""
+    headings = parse_headings(text)
+    if not headings:
+        errors.append((path, 1, "no headings found in file"))
+        return
+
+    line, level, title = headings[0]
+    if level != 2:
+        errors.append(
+            (path, line, f"first heading must be level 2 (##); got level {level}")
+        )
+    if not re.match(r"^LLM\d{2}:\s*\S", title):
+        errors.append(
+            (
+                path,
+                line,
+                "Track B entries require '## LLMXX: <Name>' top heading "
+                f"(got: '{title}')",
+            )
+        )
+
+    _check_required_sections(path, text, errors)
+    _check_no_level_skips(path, text, errors)
+    _check_references(path, text, errors)
+    _check_us_english(path, text, errors)
+
+
+def check_track_a(path: Path, text: str, errors: list) -> None:
+    """Validate a Track A (new_entry_candidates/<slug>.md) entry."""
+    if not re.match(r"^[a-z0-9][a-z0-9-]*\.md$", path.name):
+        errors.append(
+            (
+                path,
+                1,
+                "Track A files must use lowercase-hyphenated slugs "
+                f"(e.g. 'model-inversion.md'); got '{path.name}'",
+            )
+        )
+
+    headings = parse_headings(text)
+    if not headings:
+        errors.append((path, 1, "no headings found in file"))
+        return
+
+    line, level, title = headings[0]
+    if level != 2:
+        errors.append(
+            (path, line, f"first heading must be level 2 (##); got level {level}")
+        )
+    if re.match(r"^LLM\d{2}:", title):
+        errors.append(
+            (
+                path,
+                line,
+                "Track A entries must NOT include 'LLMXX:' prefix in the heading; "
+                "numbering is assigned at promotion",
+            )
+        )
+
+    _check_required_sections(path, text, errors)
+    _check_no_level_skips(path, text, errors)
+    _check_references(path, text, errors)
+    _check_us_english(path, text, errors)
+
+
+def check_template(path: Path, text: str, errors: list) -> None:
+    """Verify the canonical template hasn't been corrupted into a real entry."""
+    if "## LLMXX: Risk Name" not in text:
+        errors.append(
+            (
+                path,
+                1,
+                "_template.md must preserve the '## LLMXX: Risk Name' placeholder. "
+                "Did you mean to create a new file in 2026/new_entry_candidates/ "
+                "instead?",
+            )
+        )
+
+
+def _check_required_sections(path: Path, text: str, errors: list) -> None:
+    """Verify all five required level-3 sections appear in order."""
+    h3 = [(line, title) for line, level, title in parse_headings(text) if level == 3]
+    h3_titles = [t for _, t in h3]
+
+    last_idx = -1
+    for required in REQUIRED_SECTIONS:
+        try:
+            idx = h3_titles.index(required)
+        except ValueError:
+            errors.append((path, 1, f"missing required section '### {required}'"))
+            continue
+        if idx <= last_idx:
+            line_no = h3[idx][0]
+            errors.append(
+                (
+                    path,
+                    line_no,
+                    f"section '### {required}' appears out of order; "
+                    f"required order: {', '.join(REQUIRED_SECTIONS)}",
+                )
+            )
+        last_idx = idx
+
+
+def _check_no_level_skips(path: Path, text: str, errors: list) -> None:
+    """Flag heading-level skips (e.g. ## -> ####)."""
+    headings = parse_headings(text)
+    prev_level = 0
+    for line, level, title in headings:
+        if prev_level and level > prev_level + 1:
+            errors.append(
+                (
+                    path,
+                    line,
+                    f"heading level skip: '{'#' * level} {title[:60]}' "
+                    f"jumps from level {prev_level} to {level}",
+                )
+            )
+        prev_level = level
+
+
+def _check_references(path: Path, text: str, errors: list) -> None:
+    """Verify reference list entries include a bolded publisher."""
+    m = re.search(
+        r"^### Reference Links\s*$\n+(.*?)(?=^\Z|^### )",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not m:
+        return  # missing-section error already emitted by _check_required_sections
+    section = m.group(1)
+    section_start_offset = m.start(1)
+    section_start_line = text[:section_start_offset].count("\n") + 1
+
+    for offset, line in enumerate(section.splitlines()):
+        line_no = section_start_line + offset
+        if not re.match(r"^\d+\.\s+\[", line):
+            continue  # blank or non-reference line
+        # Bolded **publisher** must appear after the URL closing paren.
+        if not re.search(r"\)\s*[: ]\s*.*?\*\*[^*]+\*\*", line):
+            errors.append(
+                (
+                    path,
+                    line_no,
+                    f"reference missing bolded publisher: '{line[:100]}'",
+                )
+            )
+
+
+def _check_us_english(path: Path, text: str, errors: list) -> None:
+    """Flag common British spellings."""
+    for i, line in enumerate(text.splitlines(), start=1):
+        for word in BRITISH_WORDS:
+            if re.search(rf"\b{word}\b", line, re.IGNORECASE):
+                errors.append(
+                    (
+                        path,
+                        i,
+                        f"British spelling '{word}' detected; use US English "
+                        "equivalent",
+                    )
+                )
+
+
+def main(argv: list[str]) -> int:
+    files = [Path(a) for a in argv]
+    if not files:
+        print(
+            "usage: check-entry-conformance.py <file1.md> [<file2.md> ...]",
+            file=sys.stderr,
+        )
+        return 0
+
+    errors: list[tuple[Path, int, str]] = []
+    for f in files:
+        if not f.exists():
+            continue
+        kind = file_kind(f)
+        if kind == "unknown":
+            continue
+        text = f.read_text(encoding="utf-8")
+        if kind == "track-b":
+            check_track_b(f, text, errors)
+        elif kind == "track-a":
+            check_track_a(f, text, errors)
+        elif kind == "template":
+            check_template(f, text, errors)
+
+    for path, line, msg in errors:
+        annotate(path, line, msg)
+
+    if errors:
+        print(
+            f"\n{len(errors)} conformance error(s) found.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/workflows/entry-conformance.yml
+++ b/.github/workflows/entry-conformance.yml
@@ -1,0 +1,128 @@
+name: entry-conformance
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "2026/LLM0[1-9]_*.md"
+      - "2026/LLM10_*.md"
+      - "2026/new_entry_candidates/**.md"
+      - "2026/_template.md"
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  check:
+    name: check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Determine changed entry files
+        id: changed
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BASE_REF" --depth=1
+          mapfile -t files < <(git diff --name-only --diff-filter=AMR \
+            "origin/${BASE_REF}...HEAD" -- \
+            '2026/LLM0[1-9]_*.md' \
+            '2026/LLM10_*.md' \
+            '2026/new_entry_candidates/**.md' \
+            '2026/_template.md' || true)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "files=" >> "$GITHUB_OUTPUT"
+            echo "No entry files changed in this PR."
+          else
+            printf 'Changed entry files:\n'
+            printf '  %s\n' "${files[@]}"
+            # Pass as null-delimited list via a file to avoid shell-quoting issues
+            printf '%s\n' "${files[@]}" > /tmp/entry-conformance-files.txt
+            echo "files=present" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run conformance check
+        id: check
+        if: steps.changed.outputs.files == 'present'
+        shell: bash
+        run: |
+          set +e
+          # Read filenames from the file written by the previous step.
+          # Using xargs -d '\n' ensures we never pass file content through the shell.
+          xargs -d '\n' -a /tmp/entry-conformance-files.txt \
+            python .github/scripts/check-entry-conformance.py \
+            > conformance.out 2>&1
+          status=$?
+          cat conformance.out
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          exit "$status"
+        continue-on-error: true
+
+      - name: Apply needs-fix label on failure
+        if: steps.check.outputs.status != '0' && steps.check.outputs.status != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr edit "$PR_NUM" --add-label needs-fix --repo "$REPO" || true
+
+      - name: Remove needs-fix label on pass
+        if: steps.check.outputs.status == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr edit "$PR_NUM" --remove-label needs-fix --repo "$REPO" 2>/dev/null || true
+
+      - name: Comment with errors on failure
+        if: steps.check.outputs.status != '0' && steps.check.outputs.status != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          {
+            echo "## :no_entry: Entry conformance check failed"
+            echo ""
+            echo "One or more changed entry files do not match the structure required by"
+            echo "[\`documentation/style/entries.md\`](../blob/main/documentation/style/entries.md)"
+            echo "and [\`2026/_template.md\`](../blob/main/2026/_template.md)."
+            echo ""
+            echo "**Errors reported by the conformance script:**"
+            echo ""
+            echo '```'
+            cat conformance.out
+            echo '```'
+            echo ""
+            echo "Push a fix to this branch and the check will re-run automatically."
+            echo "To run the check yourself before pushing:"
+            echo ""
+            echo '```bash'
+            echo 'python .github/scripts/check-entry-conformance.py 2026/LLM01_PromptInjection.md'
+            echo '```'
+            echo ""
+            echo "_This comment was posted automatically by \`.github/workflows/entry-conformance.yml\`._"
+          } > comment.md
+          gh pr comment "$PR_NUM" --repo "$REPO" --body-file comment.md
+
+      - name: Fail the job on conformance error
+        if: steps.check.outputs.status != '0' && steps.check.outputs.status != ''
+        run: |
+          echo "Conformance errors above. Job failing so the status check blocks merge."
+          exit 1

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,24 @@
+name: markdown-lint
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - ".markdownlint.json"
+      - ".github/workflows/markdown-lint.yml"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - ".markdownlint.json"
+      - ".github/workflows/markdown-lint.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: "**/*.md"
+          config: ".markdownlint.json"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,23 @@
+{
+  "default": true,
+  "MD001": false,
+  "MD004": false,
+  "MD005": false,
+  "MD009": false,
+  "MD012": false,
+  "MD013": false,
+  "MD022": false,
+  "MD024": false,
+  "MD025": false,
+  "MD026": false,
+  "MD029": false,
+  "MD031": false,
+  "MD033": false,
+  "MD034": false,
+  "MD036": false,
+  "MD038": false,
+  "MD040": false,
+  "MD041": false,
+  "MD045": false,
+  "MD047": false
+}


### PR DESCRIPTION
## Summary

Adds an automated CI gate that enforces the entry structure rules from `documentation/style/entries.md` and `2026/_template.md`. Also commits two CI files that were previously untracked locally (`markdown-lint.yml` and `.markdownlint.json`) — the contributing docs reference them but they were never on `main`.

**Opened as draft pending review of the conformance-rule strictness vs. existing-state gap discussed below.**

## What's added

| File | Purpose |
|------|---------|
| `.github/scripts/check-entry-conformance.py` | Stdlib-only Python validator. Distinguishes Track A (new_entry_candidates), Track B (LLM01–LLM10), and `_template.md`. Checks: required-section presence + ordering, ATX heading levels with no skips, reference format (bold publisher), common British spellings, Track A slug shape, LLMXX prefix presence/absence per track, template placeholder integrity. |
| `.github/workflows/entry-conformance.yml` | `pull_request` workflow with path filter — only runs on PRs that touch `2026/LLM*_*.md`, `2026/new_entry_candidates/**.md`, or `2026/_template.md`. PRs touching only README/CONTRIBUTING/etc. skip it entirely (your stated requirement). |
| `.github/workflows/markdown-lint.yml` | Previously untracked. Commits the existing markdownlint-cli2 workflow so CLAUDE.md / CONTRIBUTING.md are no longer aspirational. |
| `.markdownlint.json` | Companion config for the above. |

## Workflow behavior on failure

Per your selection (Option B):

1. Post a comment with the specific errors (file + line + message)
2. Apply a `needs-fix` label
3. Job fails — once wired up as a required status check, this blocks merge
4. Does **not** auto-close the PR

On a clean push, the comment-posting step is skipped and the `needs-fix` label is removed automatically.

## Existing-state gap (action required before enabling as a required status check)

Running the script against the current `2026/` directory flags **36 conformance errors**:

| Issue category | Count | Affected files |
|---|---|---|
| `### Common Examples of Vulnerability` (older 2025 phrasing) instead of template's `### Common Examples of Risk` | 7 | LLM01, LLM02, LLM03, LLM04, LLM06, LLM08, LLM10 |
| References missing bolded publisher | ~22 | LLM01 (3 of 34), LLM03 (10 of 12), LLM07 (5 of 5), LLM08 (8 of 8), LLM10 (1 of 8) |
| Missing required sections (`### Reference Links` in LLM02, `### Example Attack Scenarios` in LLM03) | 2 | LLM02, LLM03 |

This means **enabling the check as a required status check today will block any future PR that touches LLM01–LLM10 until the touching PR also fixes the pre-existing issues in that file.** Friction on every contributor.

### Three options for bridging the gap

1. **One-time cleanup PR(s)** — open a PR per affected entry that brings it into conformance with the script (rename headings, bold publishers). Entry leads review their respective entries. Most correct path; clears the debt before tightening the gate. ~30 minutes of mechanical edits per entry.
2. **Phased enablement** — leave the workflow unblocking initially (just comment + label, no required-status check). Fix entries incrementally as part of normal upgrades. Turn on the required status check later when the existing state is clean.
3. **Add transitional aliases to the script** — accept both `Common Examples of Vulnerability` and `Common Examples of Risk` for a transitional period. Reduces enforcement value but lets the gate turn on now without forcing immediate cleanup.

My recommendation: **Option 1** (cleanup PRs first) for the structural issues, since they are pure renames; **Option 2** for reference-format gaps, since some refs lack bibliographic information that would need to be researched (not pure formatting).

## Workflow security review

All GitHub-context inputs (`github.base_ref`, `pull_request.number`, `github.repository`) flow through `env:` blocks, never inlined directly into `run:` shell expansions. The list of changed filenames is written to `/tmp/entry-conformance-files.txt` and consumed by `xargs -d '\n'` so filenames containing shell metacharacters cannot be executed.

## Next steps after this PR merges

To activate the required-status-check gate (admin-only):

```bash
# Verify the workflow has run cleanly on at least one PR first.
gh api repos/GenAI-Security-Project/GenAI-LLM-Top10/branches/main/protection/required_status_checks/contexts \\
  -X POST \\
  -f 'contexts[]=entry-conformance / check' \\
  -f 'contexts[]=markdown-lint / lint'
```

Until that step, the workflow runs and reports but does not gate merges.

## Test plan

- [x] Python script syntax-checks cleanly
- [x] Both YAML files parse with `yaml.safe_load`
- [x] Script tested locally against all 11 files in `2026/` (10 entries + template); produces expected annotations
- [ ] Workflow runs in CI on this PR itself (this PR doesn't touch entry files, so the workflow won't trigger here — that's by design and validates the path filter)
- [ ] After merge, open a small test PR that intentionally fails one rule to confirm the comment + label flow works end-to-end before enabling as required check