### PR TITLE
sprint-2: add 2026 polling infrastructure for community feedback

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Vote (single ballot, both tracks)
+    url: https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform
+    about: Score Importance and Clarity for the 10 existing entries, plus Distinctness for the 8 new candidates. Single submission. Estimated 10 minutes if you score every entry.
+  - name: General discussion (Sprint 2)
+    url: https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/discussions
+    about: For comments not tied to a specific entry. Cross-cutting questions, proposed new entries, process feedback.
+  - name: OWASP Top 10 for LLM project page
+    url: https://genai.owasp.org/llm-top-10/
+    about: Project background, charter, and Sprint 2 timeline.

--- a/.github/ISSUE_TEMPLATE/feedback-track-a.yml
+++ b/.github/ISSUE_TEMPLATE/feedback-track-a.yml
@@ -1,0 +1,91 @@
+name: Sprint 2 Feedback — Track A (Existing Entry)
+description: Comment on a refreshed existing Top 10 entry. Use the linked Google Form for Importance and Clarity scores.
+title: "[Track A] Feedback: <ENTRY_ID> — <ENTRY_TITLE>"
+labels:
+  - sprint-2
+  - track-a
+  - feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Sprint 2 Community Review — Track A
+
+        Use this issue to leave **qualitative feedback** on the refreshed entry. Use the **Google Form** to submit your **Importance** and **Clarity** scores. One ballot covers all 18 entries (both tracks). The form and these issues are linked but separate by design.
+
+        - Vote: https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform — page through to the relevant Track A entry
+        - Voting closes: **May 18, 2026 at 23:59 UTC**
+        - Code of Conduct: [OWASP Code of Conduct](https://owasp.org/www-policy/operational/code-of-conduct)
+
+        ### Scoring rubric
+
+        - **Importance** (1–5): How critical is this risk to LLM application security in 2026?
+        - **Clarity** (1–5): How clearly does the entry describe the risk and its mitigations?
+
+        ### What good feedback looks like
+
+        - Specific to this entry (not the Top 10 as a whole)
+        - References a definition, example, or mitigation that is missing, wrong, or outdated
+        - Includes a citation, CVE, incident, or research finding when possible
+        - Proposes language, not just objections
+
+  - type: input
+    id: entry_id
+    attributes:
+      label: Entry ID
+      description: Confirm the entry you are commenting on (e.g., LLM01).
+      placeholder: LLM01
+    validations:
+      required: true
+
+  - type: dropdown
+    id: feedback_type
+    attributes:
+      label: Feedback category
+      description: Pick the closest match. Use one issue per category if you have multiple types of feedback.
+      options:
+        - Definition or scope
+        - Common examples
+        - Prevention or mitigation strategies
+        - Attack scenarios
+        - Reference or supporting research
+        - Editorial (clarity, formatting, terminology)
+        - Suggest merging with another entry
+        - Suggest splitting into multiple entries
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: feedback_body
+    attributes:
+      label: Your feedback
+      description: Be specific. Quote the section or phrase you are referring to. Propose alternative language where possible.
+      placeholder: |
+        Section: <which section of the entry>
+        Issue: <what is wrong, missing, or unclear>
+        Proposed change: <your suggested fix or addition>
+        Evidence: <CVE, paper, incident, or research note ID if applicable>
+    validations:
+      required: true
+
+  - type: input
+    id: github_handle
+    attributes:
+      label: GitHub username (optional)
+      description: For voters who also commented here. Helps cross-validate engagement against the ballot data.
+      placeholder: "@your-handle"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Acknowledgments
+      options:
+        - label: I have read the entry I am commenting on.
+          required: true
+        - label: I agree to abide by the OWASP Code of Conduct.
+          required: true
+        - label: I understand my comment will be public and may be quoted in Sprint 3 working notes.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feedback-track-b.yml
+++ b/.github/ISSUE_TEMPLATE/feedback-track-b.yml
@@ -1,0 +1,118 @@
+name: Sprint 2 Feedback — Track B (New Candidate Entry)
+description: Comment on a new candidate entry. Use the linked Google Form for Importance, Clarity, and Distinctness scores.
+title: "[Track B] Feedback: <CANDIDATE_TITLE>"
+labels:
+  - sprint-2
+  - track-b
+  - feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Sprint 2 Community Review — Track B
+
+        Use this issue to leave **qualitative feedback** on this candidate. Use the **Google Form** to submit your **Importance**, **Clarity**, and **Distinctness** scores. One ballot covers all 18 entries (both tracks).
+
+        - Vote: https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform — page through to the Track B section, then to this candidate
+        - Voting closes: **May 18, 2026 at 23:59 UTC**
+        - Code of Conduct: [OWASP Code of Conduct](https://owasp.org/www-policy/operational/code-of-conduct)
+
+        ### Scoring rubric
+
+        - **Importance** (1–5): How critical is this risk to LLM application security in 2026?
+        - **Clarity** (1–5): How clearly does the candidate describe the risk and mitigations?
+        - **Distinctness** (1–5): Is this materially different from existing entries (LLM01–LLM10), or could it be merged into one of them?
+
+        ### Why Distinctness matters
+
+        Sprint 3 cuts 8 candidates down to 5. A high-Importance candidate that overlaps heavily with an existing entry is a merge target, not a standalone winner. Distinctness scores let the working group make defensible cut/keep/merge calls.
+
+        ### What good feedback looks like
+
+        - Specific to this candidate (not the Top 10 as a whole)
+        - Names the existing entry (LLM01–LLM10) this candidate overlaps with, if any
+        - References a citation, CVE, incident, or research note when possible
+        - Proposes language for definitions, examples, or mitigations
+
+  - type: input
+    id: candidate_id
+    attributes:
+      label: Candidate ID
+      description: The TB-XXXX label for this candidate (e.g., TB-MCPX).
+      placeholder: TB-MCPX
+    validations:
+      required: true
+
+  - type: dropdown
+    id: feedback_type
+    attributes:
+      label: Feedback category
+      description: Pick the closest match. Use one issue per category if you have multiple types of feedback.
+      options:
+        - Definition or scope
+        - Common examples
+        - Prevention or mitigation strategies
+        - Attack scenarios
+        - Reference or supporting research
+        - Distinctness — overlaps with existing entry
+        - Distinctness — should be merged into another candidate
+        - Editorial (clarity, formatting, terminology)
+        - Recommend dropping from consideration
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: overlap_with
+    attributes:
+      label: If this overlaps with an existing entry, which one?
+      description: Optional. Only fill if you flagged Distinctness as your feedback category.
+      options:
+        - "N/A — this is distinct"
+        - LLM01 Prompt Injection
+        - LLM02 Sensitive Information Disclosure
+        - LLM03 Supply Chain
+        - LLM04 Data and Model Poisoning
+        - LLM05 Improper Output Handling
+        - LLM06 Excessive Agency
+        - LLM07 System Prompt Leakage
+        - LLM08 Vector and Embedding Weaknesses
+        - LLM09 Misinformation
+        - LLM10 Unbounded Consumption
+        - Multiple existing entries (specify in body)
+    validations:
+      required: false
+
+  - type: textarea
+    id: feedback_body
+    attributes:
+      label: Your feedback
+      description: Be specific. Quote the section or phrase you are referring to. Propose alternative language where possible.
+      placeholder: |
+        Section: <which section of the candidate>
+        Issue: <what is wrong, missing, unclear, or duplicative>
+        Proposed change: <your suggested fix, addition, or merge target>
+        Evidence: <CVE, paper, incident, or research note ID if applicable>
+    validations:
+      required: true
+
+  - type: input
+    id: github_handle
+    attributes:
+      label: GitHub username (optional)
+      description: For voters who also commented here. Helps cross-validate engagement against the ballot data.
+      placeholder: "@your-handle"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Acknowledgments
+      options:
+        - label: I have read the candidate entry I am commenting on.
+          required: true
+        - label: I agree to abide by the OWASP Code of Conduct.
+          required: true
+        - label: I understand my comment will be public and may be quoted in Sprint 3 working notes.
+          required: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+2026/Leads/
+
+# OWASP Top 10 LLM 2026 — Sprint 2 polling
+2026/polling/comms/
+2026/polling/forms/create_forms_execution_log.txt
+__pycache__/
+*.pyc
+.DS_Store

--- a/2026/polling/README.md
+++ b/2026/polling/README.md
@@ -1,0 +1,142 @@
+# Sprint 2 Polling Infrastructure
+
+OWASP Top 10 for LLM Applications — 2026 Update
+Sprint 2: Community Review and Voting (May 4–18, 2026)
+
+Owner: Rock Lambros (rock@rockcyber.ai)
+Co-lead: Steve Wilson
+
+This folder contains everything needed to run Sprint 2 community voting and feedback collection. Single combined Google Form covering both tracks (10 existing entries plus 8 new candidates), 18 GitHub issues for qualitative comments.
+
+## Folder layout
+
+```
+polling/
+├── README.md                              # this file
+├── .gitignore
+├── .github/
+│   └── ISSUE_TEMPLATE/
+│       ├── feedback-track-a.yml           # issue form for existing-entry feedback
+│       ├── feedback-track-b.yml           # issue form for candidate-entry feedback
+│       └── config.yml                     # disables blank issues, adds vote link
+├── forms/
+│   ├── create_form.gs                     # Apps Script: builds the Sprint 2 Google Form
+│   └── blueprint.md                       # human-readable Form spec
+└── scripts/
+    ├── issues.json                        # 22 labels + 18 issue payloads
+    └── create_issues.py                   # bulk issue creator (idempotent)
+```
+
+When this folder lands in the GenAI-LLM-Top10 repo, the `.github/ISSUE_TEMPLATE/` files move to the repo root's `.github/ISSUE_TEMPLATE/` (not under `polling/`). The rest stays where it is.
+
+## Run order
+
+This is the operating sequence. Each step gates the next.
+
+### 1. Create the Form (Apps Script) — **DONE**
+
+Form was generated on May 4, 2026 from `forms/create_form.gs` running under Rock's Google account.
+
+- **Published URL** (used by GitHub issues): https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform
+- **Short URL** (use for LinkedIn, Slack, mailing list): https://forms.gle/jFmqZF1R6k9gCEfi6
+- **Form ID**: `1lNZHaqUQC_A9DJeSy9JJ1FQkzE1T-lA92vbJLoE6K_k`
+
+The Form ID feeds the aggregation pipeline (it identifies the linked response Sheet). All values are stored in `scripts/issues.json` under `_meta.form` for traceability.
+
+If the form ever needs to be regenerated, re-run `createSprintTwoForm()` in Apps Script and update both files plus the issue templates with the new URL/ID.
+
+### 2. Land the issue templates — **DONE (URLs baked in)**
+
+Copy `polling/.github/ISSUE_TEMPLATE/*.yml` to `.github/ISSUE_TEMPLATE/` in the repo root and commit. The Form URL is already baked into all three template files. No further substitution needed. Templates take effect immediately on `main`.
+
+### 3. Create the 18 feedback issues — **DONE**
+
+Issues fired May 4, 2026 via the Python script (`create_issues.py`) running under Rock's gh CLI auth. 22 labels upserted, 10 Track A issues, 8 Track B issues. Filter: https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/issues?q=is%3Aissue+label%3Asprint-2
+
+If you ever need to re-run (e.g., to add a candidate mid-sprint):
+
+```bash
+export GH_TOKEN=$(gh auth token)
+cd polling/scripts
+
+python3 create_issues.py \
+  --form-url "https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform" \
+  --dry-run
+
+python3 create_issues.py \
+  --form-url "https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform"
+```
+
+The script is idempotent on labels (existing labels get patched, not duplicated) but **not** on issues. Re-running creates duplicates.
+
+### 4. Pin the launch announcement — **DONE**
+
+Pinned Discussion: https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/discussions/54
+
+Body sourced from `comms/github_discussion_pinned.md`. The Discussion is the FAQ + cross-cutting comment venue for Sprint 2.
+
+## Why one combined form
+
+Single URL to promote, single captive audience. A voter who finishes the existing entries (Track A) rolls naturally into the new candidates (Track B) instead of needing to remember a second link. Track B participation rises. Comms simplify.
+
+The cost is voter fatigue mid-form. All Likert questions are optional, so drop-off is graceful and tracked as a metric in aggregation. Per-entry response rate proxies completion. The aggregation pipeline distinguishes "completed Track A only" from "completed both" so partial ballots still count.
+
+Tracks remain analytically separate. Question titles tag every score with its entry ID (`LLM01 — Importance`, `TB-MCPX — Distinctness`), so the aggregation pipeline splits the data cleanly.
+
+## Voter integrity
+
+A public OWASP vote is a brigading target. The integrity story:
+
+- **Email collection** in the Form enforces dedup. Workspace-only `setLimitOneResponsePerUser` is best-effort; real dedup runs in the aggregation pipeline.
+- **GitHub username** field is optional but cross-validated against repo activity (commenters, stargazers) as a soft signal.
+- **Affiliation and self-rated familiarity** allow stratified analysis without disqualifying any voter.
+- **Likert questions are optional** so unfamiliar voters skip rather than guess. Skip rate is a metric, not a failure.
+- **Anomaly detection** in the aggregation pipeline: vote-velocity spikes, timestamp clustering, mismatch between affiliation and familiarity claims.
+
+The aggregation pipeline (built separately in Sprint 2 week 2) consumes the Sheet and the 18 issue threads, deduplicates by email, runs the integrity checks, and emits the ranked tally for Sprint 3. Reports include median, mean, N, standard deviation, IQR, skip rate, distribution histograms, Importance × Clarity quadrant plots, bootstrap rank stability, stratified views, and brigading flags.
+
+## What this folder does **not** include
+
+- The aggregation notebook (separate deliverable, week 2 of Sprint 2)
+- Communications copy (LinkedIn, Slack, mailing list)
+- Comment triage templates (entry leads own these)
+- The Sprint 3 selection playbook
+
+These are scoped for follow-on work once the ballot is live.
+
+## Editing the configuration
+
+If a candidate is added or dropped before launch:
+
+1. Edit the entry array in **both** `forms/create_form.gs` and `scripts/issues.json`
+2. Re-run the Apps Script (creates a new Form; old Form can be deleted)
+3. Re-run `create_issues.py` only for the new entries (delete duplicate old issues manually)
+
+Adding entries mid-sprint resets voting baselines. Avoid if possible.
+
+## Decisions baked into this design
+
+| Decision | Rationale |
+| --- | --- |
+| Single combined Form (Track A then Track B) | One URL to promote. Captive audience rolls from familiar existing entries into new candidates. Higher Track B participation. |
+| Track B includes Distinctness Likert | Sprint 3 cuts 8→5. High-Importance candidates that overlap heavily with existing entries are merge targets, not standalone winners. Distinctness gives a defensible cut/keep/merge signal. |
+| All Likerts optional, none required | Forced votes from unqualified voters add noise. Skip rate is a deliberate metric. |
+| Each entry on its own page | Progress visible. Voters can stop and resume. |
+| GitHub for comments, Form for scores | Comments need durability and version history (GitHub). Structured numeric data needs clean export (Form → Sheet). Two systems, linked, each playing to its strength. |
+| Email collection on, Workspace-only enforcement off | Public OWASP vote will not have Workspace. Dedup happens in aggregation. |
+| Median + mean + 9 other diagnostics | Median is the headline ranking. Diagnostics defend the rank in Sprint 4. |
+
+## Known limitations
+
+- **Section deep-linking**: Google Forms always opens at page 1. Voters arriving from a specific entry's GitHub issue still see "About You" first and have to page through. The issue body explains the navigation.
+- **Order bias**: Track A always precedes Track B. Each track lists entries in canonical order. Voters who fatigue mid-form score later entries less generously. Aggregation reports per-entry response rate to flag.
+- **Drop-off mid-form**: 19 pages is long. Aggregation tracks completion per entry as the participation signal.
+- **Workspace gating**: native one-response-per-user enforcement requires Workspace. Email dedup compensates.
+- **Brigading risk**: a public Form is a brigading target. Anomaly detection compensates.
+- **Comment-vote correlation is weak**: voters who comment may not vote. The integrity playbook tracks both populations and reports overlap.
+
+## Contact
+
+Working group questions: Rock Lambros (rock@rockcyber.ai) or Steve Wilson via the OWASP Slack channel.
+
+Process or technical questions about this infrastructure: open a Discussion on the repo.

--- a/2026/polling/forms/blueprint.md
+++ b/2026/polling/forms/blueprint.md
@@ -1,0 +1,159 @@
+# Sprint 2 Voting Form — Blueprint
+
+Owner: Rock Lambros (rock@rockcyber.ai)
+Version: 2.1 (form generated and live)
+Last Updated: May 4, 2026
+
+This document specifies the single Google Form used for Sprint 2 voting. The Apps Script `create_form.gs` builds it programmatically. This blueprint is the source of truth if the script ever drifts.
+
+## Live form references
+
+- **Published URL** (canonical, for GitHub issues and durable references): https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform
+- **Short URL** (for human-shared comms — LinkedIn, Slack, mailing list): https://forms.gle/jFmqZF1R6k9gCEfi6
+- **Form ID**: `1lNZHaqUQC_A9DJeSy9JJ1FQkzE1T-lA92vbJLoE6K_k`
+- **Generated**: May 4, 2026 from `create_form.gs`
+- **Owner account**: Rock Lambros' Google account
+- **Response destination**: Linked Google Sheet (created via the Forms UI; aggregation pipeline reads via Form ID)
+
+## Single ballot, both tracks
+
+One form covers Track A (10 existing entries) and Track B (8 new candidates). Voters land on a single URL, fill what they know, skip what they don't. The "captive audience" design boosts Track B participation by routing voters there after they finish the more familiar Track A entries.
+
+Tracks remain analytically separate. Question titles tag every score with its entry ID (`LLM01 — Importance`, `TB-MCPX — Distinctness`), so the aggregation pipeline splits the data cleanly. Sprint plan still evaluates the tracks independently.
+
+## Voting close
+
+Form closes May 18, 2026 at 23:59 UTC. The aggregation pipeline runs on May 19.
+
+## Form-level settings
+
+| Setting | Value | Why |
+| --- | --- | --- |
+| Collect email addresses | On | Dedup key for the analysis pipeline |
+| Limit to one response | On (Workspace only) | Soft control; real dedup runs in analysis |
+| Allow response edits | On | Voters can refine without resubmitting |
+| Show "Submit another response" link | Off | Mild dedup signal |
+| Progress bar | On | Critical for retention on a 19-page form |
+| Confirmation message | Custom (see script) | Sets expectation about Sprint 3 |
+
+## Form structure (page-by-page)
+
+| Page | Content | Required fields |
+| --- | --- | --- |
+| 1 | About You — voter metadata | Affiliation, familiarity, single-ballot pledge |
+| 2 | Track A intro + LLM01 (Prompt Injection) scoring | None (all Likerts optional) |
+| 3 | LLM02 Sensitive Information Disclosure | None |
+| 4 | LLM03 Supply Chain | None |
+| 5 | LLM04 Data and Model Poisoning | None |
+| 6 | LLM05 Improper Output Handling | None |
+| 7 | LLM06 Excessive Agency | None |
+| 8 | LLM07 System Prompt Leakage | None |
+| 9 | LLM08 Vector and Embedding Weaknesses | None |
+| 10 | LLM09 Misinformation | None |
+| 11 | LLM10 Unbounded Consumption | None |
+| 12 | Track B intro + TB-CFAS (Compositional Fine-Tuning Alignment Subversion) | None |
+| 13 | TB-CMSB Cross-Modal Safety Bypass | None |
+| 14 | TB-ITSC Inference-Time Side-Channel Disclosure | None |
+| 15 | TB-MCPX MCP Tool Interface Exploitation | None |
+| 16 | TB-MMIS Model Misalignment | None |
+| 17 | TB-MSDA Model Scheming and Deceptive Alignment | None |
+| 18 | TB-SICG Systemic Insecure Code Generation | None |
+| 19 | TB-WLLA Weaponized LLM Abuse | None |
+
+Total: 19 pages. Estimated completion time 10 minutes if voter scores everything, 1–2 minutes if voter scores one entry.
+
+## Voter metadata page (page 1)
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| Email | Auto-collected by Forms | Yes | Dedup key |
+| Affiliation | Dropdown (8 options) | Yes | Stratification, transparency reporting |
+| Self-rated familiarity | Dropdown (Novice / Practitioner / Expert) | Yes | Stratification |
+| GitHub username | Text | No | Optional cross-validation against repo activity |
+| Single-ballot pledge | Multiple choice (I confirm) | Yes | Reminder, not enforcement |
+
+Affiliation options: Industry — security or engineering; Industry — leadership; Academia or research; Consultancy or professional services; Independent practitioner; Government or regulator; Student; Prefer not to say.
+
+## Per-entry section
+
+Each entry is on its own page. The section header at the top of every entry page contains:
+
+- Entry ID and title
+- Direct link to the draft markdown on GitHub
+- Direct link to the entry's GitHub feedback issue (filtered by label)
+
+### Track A: 2 Likert questions per entry
+
+| Question | Scale | Required |
+| --- | --- | --- |
+| Importance | 1–5 (1 Not important, 5 Critical) | No |
+| Clarity | 1–5 (1 Confusing, 5 Crystal clear) | No |
+| Brief comment | Paragraph text | No |
+
+### Track B: 3 Likert questions per entry
+
+| Question | Scale | Required |
+| --- | --- | --- |
+| Importance | 1–5 (1 Not important, 5 Critical) | No |
+| Clarity | 1–5 (1 Confusing, 5 Crystal clear) | No |
+| Distinctness | 1–5 (1 Already covered, 5 Clearly distinct) | No |
+| Brief comment | Paragraph text | No |
+
+Distinctness is Track B only. It tells Sprint 3 whether a high-Importance candidate is a standalone entry or a merge into an existing one. Cuts the risk of Sprint 4 churn over duplicative entries.
+
+### Why all Likerts are optional
+
+Skipping is a deliberate signal. Voters who do not feel qualified to score an entry should leave it blank. Skip rate per entry feeds the analysis. Forcing a vote produces noise.
+
+## Track A entries (10)
+
+| ID | Title | Draft file |
+| --- | --- | --- |
+| LLM01 | Prompt Injection | LLM01_PromptInjection.md |
+| LLM02 | Sensitive Information Disclosure | LLM02_SensitiveInformationDisclosure.md |
+| LLM03 | Supply Chain | LLM03_SupplyChain.md |
+| LLM04 | Data and Model Poisoning | LLM04_DataModelPoisoning.md |
+| LLM05 | Improper Output Handling | LLM05_ImproperOutputHandling.md |
+| LLM06 | Excessive Agency | LLM06_ExcessiveAgency.md |
+| LLM07 | System Prompt Leakage | LLM07_SystemPromptLeakage.md |
+| LLM08 | Vector and Embedding Weaknesses | LLM08_VectorAndEmbeddingWeaknesses.md |
+| LLM09 | Misinformation | LLM09_Misinformation.md |
+| LLM10 | Unbounded Consumption | LLM10_UnboundedConsumption.md |
+
+## Track B candidates (8)
+
+| ID | Title | Draft file |
+| --- | --- | --- |
+| TB-CFAS | Compositional Fine-Tuning Alignment Subversion | compositional-finetuning-alignment-subversion.md |
+| TB-CMSB | Cross-Modal Safety Bypass | cross-modal-safety-bypass.md |
+| TB-ITSC | Inference-Time Side-Channel Disclosure | inference-time-side-channel-disclosure.md |
+| TB-MCPX | MCP Tool Interface Exploitation | mcp-tool-interface-exploitation.md |
+| TB-MMIS | Model Misalignment | model-misalignment.md |
+| TB-MSDA | Model Scheming and Deceptive Alignment | model-scheming-and-deceptive-alignment.md |
+| TB-SICG | Systemic Insecure Code Generation | systemic-insecure-code-generation.md |
+| TB-WLLA | Weaponized LLM Abuse | weaponized-llm-abuse.md |
+
+The TB-XXXX IDs are GitHub label values. They keep issue filter URLs short and stable even if the candidate title changes.
+
+## Known limitations
+
+**Section deep-linking**: Google Forms always opens at page 1. Issues for specific entries link to the same Form URL. The issue body explains how to navigate. Voters who land on the form from an LLM05 issue still see "About You" first and have to page through to LLM05. Acceptable cost for the captive-audience benefit.
+
+**Order bias**: Track A always comes before Track B. Track A always lists LLM01 → LLM10 in canonical order. Voters who fatigue mid-form score later entries less generously. Aggregation reports completion rate per entry to flag this.
+
+**Drop-off mid-form**: 19 pages. Some voters will abandon partway through. The aggregation pipeline tracks "completed Track A only" vs "completed both" as a participation segmentation, and reports per-entry response rate as a completion proxy.
+
+**Workspace gating**: `setLimitOneResponsePerUser` only enforces inside Google Workspace. Public OWASP voting will not have it. Email dedup in aggregation compensates.
+
+**Brigading risk**: a public form is a brigading target. Anomaly detection in aggregation looks at vote velocity, timestamp clustering, and new-account signals via the optional GitHub handle.
+
+## How to run
+
+1. Open https://script.google.com and create a new project.
+2. Paste `create_form.gs` into Code.gs.
+3. Run `createSprintTwoForm()`.
+4. Authorize when prompted (FormApp + Drive scopes).
+5. Copy the **Published URL** from the execution log.
+6. Pass that URL to `../scripts/create_issues.py --form-url ...` to create the 18 GitHub feedback issues.
+
+The Form auto-routes responses to a Google Sheet. The aggregation pipeline (separate deliverable) reads that Sheet by Form ID.

--- a/2026/polling/forms/create_form.gs
+++ b/2026/polling/forms/create_form.gs
@@ -1,0 +1,277 @@
+/**
+ * OWASP Top 10 for LLM Applications — 2026 Update
+ * Sprint 2 Voting Form Generator (single combined ballot, both tracks)
+ *
+ * Owner: Rock Lambros (rock@rockcyber.ai)
+ * Version: 2.0  (consolidated from prior dual-form design)
+ *
+ * WHAT THIS DOES
+ *   Programmatically creates the Sprint 2 Google Form covering both tracks:
+ *     - Track A: 10 existing entries (Importance + Clarity)
+ *     - Track B:  8 new candidates  (Importance + Clarity + Distinctness)
+ *
+ *   One ballot, one URL, one captive audience. All Likerts are optional.
+ *   Voters skip any entry they have not read. Skip rate is a deliberate metric.
+ *
+ * USAGE
+ *   1. Go to https://script.google.com and create a new project
+ *   2. Paste this entire file into Code.gs
+ *   3. Run createSprintTwoForm()
+ *   4. Authorize when prompted (FormApp + Drive scopes)
+ *   5. The execution log prints:
+ *        - Published URL  (share this with voters and paste into create_issues.py)
+ *        - Edit URL       (for the working group)
+ *        - Form ID        (used by the aggregation pipeline)
+ *
+ * NOTES
+ *   - setLimitOneResponsePerUser is a Google Workspace feature. If the project
+ *     is not on a Workspace account, the call is a no-op and dedup falls to
+ *     the aggregation pipeline (which dedups by collected email).
+ *   - Track A appears first because the existing entries are familiar; that
+ *     builds voter momentum into the Track B section.
+ *   - Each entry is on its own page so voters see progress and can resume.
+ */
+
+// ---------- Configuration ----------
+
+const FORM_TITLE =
+  'OWASP Top 10 for LLM Applications 2026 — Sprint 2 Community Vote';
+
+const REPO_ENTRY_BASE =
+  'https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/blob/main/2026/';
+
+const REPO_CANDIDATE_BASE =
+  'https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/blob/main/2026/new_entry_candidates/';
+
+const REPO_ISSUE_BASE_A =
+  'https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/issues?q=is%3Aissue+label%3Atrack-a+label%3A';
+
+const REPO_ISSUE_BASE_B =
+  'https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/issues?q=is%3Aissue+label%3Atrack-b+label%3A';
+
+const VOTING_CLOSE = 'May 18, 2026 at 23:59 UTC';
+
+const TRACK_A_ENTRIES = [
+  { id: 'LLM01', title: 'Prompt Injection',                       file: 'LLM01_PromptInjection.md' },
+  { id: 'LLM02', title: 'Sensitive Information Disclosure',       file: 'LLM02_SensitiveInformationDisclosure.md' },
+  { id: 'LLM03', title: 'Supply Chain',                           file: 'LLM03_SupplyChain.md' },
+  { id: 'LLM04', title: 'Data and Model Poisoning',               file: 'LLM04_DataModelPoisoning.md' },
+  { id: 'LLM05', title: 'Improper Output Handling',               file: 'LLM05_ImproperOutputHandling.md' },
+  { id: 'LLM06', title: 'Excessive Agency',                       file: 'LLM06_ExcessiveAgency.md' },
+  { id: 'LLM07', title: 'System Prompt Leakage',                  file: 'LLM07_SystemPromptLeakage.md' },
+  { id: 'LLM08', title: 'Vector and Embedding Weaknesses',        file: 'LLM08_VectorAndEmbeddingWeaknesses.md' },
+  { id: 'LLM09', title: 'Misinformation',                         file: 'LLM09_Misinformation.md' },
+  { id: 'LLM10', title: 'Unbounded Consumption',                  file: 'LLM10_UnboundedConsumption.md' },
+];
+
+const TRACK_B_ENTRIES = [
+  { id: 'TB-CFAS', title: 'Compositional Fine-Tuning Alignment Subversion', file: 'compositional-finetuning-alignment-subversion.md' },
+  { id: 'TB-CMSB', title: 'Cross-Modal Safety Bypass',                       file: 'cross-modal-safety-bypass.md' },
+  { id: 'TB-ITSC', title: 'Inference-Time Side-Channel Disclosure',          file: 'inference-time-side-channel-disclosure.md' },
+  { id: 'TB-MCPX', title: 'MCP Tool Interface Exploitation',                 file: 'mcp-tool-interface-exploitation.md' },
+  { id: 'TB-MMIS', title: 'Model Misalignment',                              file: 'model-misalignment.md' },
+  { id: 'TB-MSDA', title: 'Model Scheming and Deceptive Alignment',          file: 'model-scheming-and-deceptive-alignment.md' },
+  { id: 'TB-SICG', title: 'Systemic Insecure Code Generation',               file: 'systemic-insecure-code-generation.md' },
+  { id: 'TB-WLLA', title: 'Weaponized LLM Abuse',                            file: 'weaponized-llm-abuse.md' },
+];
+
+// ---------- Entry point ----------
+
+function createSprintTwoForm() {
+  const form = FormApp.create(FORM_TITLE);
+
+  // FormApp.create() sets the Drive file name only. The display title shown
+  // to voters defaults to "Untitled form" until setTitle() is called.
+  form.setTitle(FORM_TITLE);
+  form.setDescription(buildDescription());
+  form.setCollectEmail(true);
+  form.setAllowResponseEdits(true);
+  form.setShowLinkToRespondAgain(false);
+  form.setProgressBar(true);
+  form.setConfirmationMessage(
+    'Thanks for voting in Sprint 2. Your scores have been recorded. ' +
+    'Comments and discussion live on the GitHub issues. Vote results ' +
+    'and the candidate-selection process publish at the start of Sprint 3.'
+  );
+
+  // Workspace-only. Wrapped because non-Workspace accounts will throw.
+  try { form.setLimitOneResponsePerUser(true); } catch (e) {
+    Logger.log('setLimitOneResponsePerUser not available (non-Workspace account). ' +
+               'Email dedup will be enforced in aggregation.');
+  }
+
+  buildVoterMetadataPage(form);
+  buildTrackAEntries(form);
+  buildTrackBEntries(form);
+
+  Logger.log('=== SPRINT 2 FORM CREATED ===');
+  Logger.log('Title:         ' + form.getTitle());
+  Logger.log('Form ID:       ' + form.getId());
+  Logger.log('Published URL: ' + form.getPublishedUrl());
+  Logger.log('Edit URL:      ' + form.getEditUrl());
+  Logger.log('Short URL:     ' + form.shortenFormUrl(form.getPublishedUrl()));
+  Logger.log('==============================');
+  Logger.log('Next step: paste the Published URL into ../scripts/create_issues.py --form-url');
+}
+
+// ---------- Description ----------
+
+function buildDescription() {
+  return [
+    'Single ballot covering both tracks of the Sprint 2 community vote:',
+    '  Track A — 10 refreshed existing entries (LLM01–LLM10)',
+    '  Track B — 8 new candidate entries',
+    '',
+    'Estimated time: 10 minutes if you score every entry. Less if you skip ' +
+    'entries you have not read. Skipping is a valid signal — it tells the ' +
+    'working group an entry is niche or under-explained.',
+    '',
+    'WHAT TO DO',
+    '1. Read each entry on GitHub (links provided per section).',
+    '2. Score Importance and Clarity on a 1–5 scale. Track B adds Distinctness.',
+    '3. Use the GitHub issue link under each entry for qualitative comments. ' +
+    'The form captures scores. The issues capture discussion.',
+    '',
+    'DEFINITIONS',
+    '• Importance: How critical is this risk to LLM application security in 2026?',
+    '• Clarity: How clearly does the entry describe the risk and mitigations?',
+    '• Distinctness (Track B only): Is this materially different from existing ' +
+    'entries (LLM01–LLM10), or could it be merged into one of them?',
+    '',
+    'INTEGRITY',
+    '• One vote per person. Dedup by email.',
+    '• Email is collected for dedup. It is not published.',
+    '• Voting closes ' + VOTING_CLOSE + '.',
+    '',
+    'CODE OF CONDUCT: ' +
+    'https://owasp.org/www-policy/operational/code-of-conduct'
+  ].join('\n');
+}
+
+// ---------- Voter metadata page ----------
+
+function buildVoterMetadataPage(form) {
+  form.addSectionHeaderItem()
+      .setTitle('About You')
+      .setHelpText('Two minutes. Used for transparency reporting and to ' +
+                   'stratify the results.');
+
+  form.addListItem()
+      .setTitle('Affiliation')
+      .setHelpText('Pick the option that best describes your primary role.')
+      .setChoiceValues([
+        'Industry — security or engineering',
+        'Industry — leadership',
+        'Academia or research',
+        'Consultancy or professional services',
+        'Independent practitioner',
+        'Government or regulator',
+        'Student',
+        'Prefer not to say'
+      ])
+      .setRequired(true);
+
+  form.addListItem()
+      .setTitle('Self-rated familiarity with LLM application security')
+      .setHelpText('Used to stratify results. Honest answers help us interpret ' +
+                   'the data. There is no "wrong" answer.')
+      .setChoiceValues([
+        'Novice — learning the space',
+        'Practitioner — work on LLM security regularly',
+        'Expert — deep specialization or published research'
+      ])
+      .setRequired(true);
+
+  form.addTextItem()
+      .setTitle('GitHub username (optional)')
+      .setHelpText('If you contribute to the repo, share your handle. We use ' +
+                   'this only to cross-validate engagement and detect anomalies.')
+      .setRequired(false);
+
+  form.addMultipleChoiceItem()
+      .setTitle('I will submit only one ballot')
+      .setHelpText('We dedup by email. This box is a reminder, not a control.')
+      .setChoiceValues(['I confirm'])
+      .setRequired(true);
+}
+
+// ---------- Track A ----------
+
+function buildTrackAEntries(form) {
+  form.addPageBreakItem()
+      .setTitle('Track A: Existing Entries (LLM01–LLM10)')
+      .setHelpText('Score Importance and Clarity for each existing entry. ' +
+                   'Leave blank any entry you have not read. Estimated time: ' +
+                   '5 minutes. Track B (new candidates) follows after this section.');
+
+  TRACK_A_ENTRIES.forEach(function (entry, idx) {
+    addEntrySection(form, entry, false /* not Track B */, REPO_ENTRY_BASE, REPO_ISSUE_BASE_A);
+    if (idx !== TRACK_A_ENTRIES.length - 1) {
+      form.addPageBreakItem();
+    }
+  });
+}
+
+// ---------- Track B ----------
+
+function buildTrackBEntries(form) {
+  form.addPageBreakItem()
+      .setTitle('Track B: New Candidate Entries')
+      .setHelpText('Now scoring new candidates for the 2026 Top 10. Sprint 3 ' +
+                   'cuts these 8 down to 5. Track B adds a third dimension — ' +
+                   'Distinctness — which tells us whether a candidate stands ' +
+                   'alone or should merge into an existing entry. Estimated ' +
+                   'time: 5 minutes. Skip any candidate you have not read.');
+
+  TRACK_B_ENTRIES.forEach(function (entry, idx) {
+    addEntrySection(form, entry, true /* Track B */, REPO_CANDIDATE_BASE, REPO_ISSUE_BASE_B);
+    if (idx !== TRACK_B_ENTRIES.length - 1) {
+      form.addPageBreakItem();
+    }
+  });
+}
+
+// ---------- Per-entry section ----------
+
+function addEntrySection(form, entry, isTrackB, draftBase, issueBase) {
+  const draftLink = draftBase + entry.file;
+  const issueLink = issueBase + encodeURIComponent(entry.id);
+  const label = isTrackB ? entry.title : (entry.id + ' — ' + entry.title);
+
+  form.addSectionHeaderItem()
+      .setTitle(label)
+      .setHelpText(
+        'Read the draft: ' + draftLink + '\n' +
+        'Comment on GitHub: ' + issueLink
+      );
+
+  form.addScaleItem()
+      .setTitle(label + ' — Importance')
+      .setHelpText('How critical is this risk to LLM application security in 2026?')
+      .setBounds(1, 5)
+      .setLabels('1 — Not important', '5 — Critical')
+      .setRequired(false);
+
+  form.addScaleItem()
+      .setTitle(label + ' — Clarity')
+      .setHelpText('How clearly does the entry describe the risk and mitigations?')
+      .setBounds(1, 5)
+      .setLabels('1 — Confusing', '5 — Crystal clear')
+      .setRequired(false);
+
+  if (isTrackB) {
+    form.addScaleItem()
+        .setTitle(label + ' — Distinctness')
+        .setHelpText('Is this distinct from existing OWASP Top 10 LLM entries ' +
+                     '(LLM01–LLM10), or could it be merged into one?')
+        .setBounds(1, 5)
+        .setLabels('1 — Already covered', '5 — Clearly distinct')
+        .setRequired(false);
+  }
+
+  form.addParagraphTextItem()
+      .setTitle(label + ' — Brief comment (optional)')
+      .setHelpText('One or two sentences max. For longer feedback use the ' +
+                   'GitHub issue linked above.')
+      .setRequired(false);
+}

--- a/2026/polling/scripts/create_issues.py
+++ b/2026/polling/scripts/create_issues.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+OWASP Top 10 for LLM Applications — 2026 Update
+Sprint 2: Bulk-create the 18 feedback issues (10 Track A + 8 Track B).
+
+Owner:    Rock Lambros (rock@rockcyber.ai)
+Version:  1.0
+Repo:     GenAI-Security-Project/GenAI-LLM-Top10
+
+WHAT THIS DOES
+  1. Ensures the 22 Sprint 2 labels exist in the repo (idempotent — creates
+     missing, leaves existing alone, updates color/description on existing).
+  2. Creates one feedback issue per existing entry (10) and per candidate (8).
+  3. Substitutes the Track A and Track B Form URLs into each issue body.
+
+USAGE
+  export GH_TOKEN="ghp_..."          # PAT with `repo` scope
+  python create_issues.py \\
+      --form-url "https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform" \\
+      --dry-run                      # render without posting
+
+  Run without --dry-run to fire for real. Issues post sequentially with a
+  short pause to stay under GitHub's secondary rate limits.
+
+  --form-url is a single Google Form URL covering both tracks. Sprint 2
+  consolidated to one ballot so voters land on a single URL and roll from
+  Track A into Track B in one captive session. The live URL is also
+  recorded in issues.json under _meta.form.published_url.
+
+EXIT CODES
+  0  success
+  1  configuration error (missing token, missing args, missing file)
+  2  GitHub API error (after creating any issues, prints which ones succeeded)
+
+DEPENDENCIES
+  Python 3.9+ stdlib only. No third-party packages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO = "GenAI-Security-Project/GenAI-LLM-Top10"
+API_BASE = "https://api.github.com"
+RATE_PAUSE_SEC = 1.0  # between issue creates
+TIMEOUT_SEC = 30
+SCRIPT_DIR = Path(__file__).resolve().parent
+ISSUES_PATH = SCRIPT_DIR / "issues.json"
+
+# ---------- HTTP ----------
+
+def _request(method: str, path: str, token: str, body: dict | None = None) -> tuple[int, Any]:
+    url = f"{API_BASE}{path}"
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    req.add_header("User-Agent", "owasp-llm-top10-2026-sprint2-issue-creator/1.0")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+            return resp.status, json.loads(resp.read().decode("utf-8") or "null")
+    except urllib.error.HTTPError as e:
+        try:
+            err_body = json.loads(e.read().decode("utf-8") or "null")
+        except Exception:
+            err_body = {"message": str(e)}
+        return e.code, err_body
+
+# ---------- Labels ----------
+
+def ensure_labels(labels: list[dict], token: str, dry_run: bool) -> None:
+    print(f"[labels] ensuring {len(labels)} labels in {REPO}")
+    for label in labels:
+        name, color, desc = label["name"], label["color"], label["description"]
+        if dry_run:
+            print(f"  [dry-run] would upsert label {name!r} color={color}")
+            continue
+
+        # Try to create. If it exists, patch.
+        status, body = _request("POST", f"/repos/{REPO}/labels", token, {
+            "name": name, "color": color, "description": desc,
+        })
+        if status == 201:
+            print(f"  + created label {name}")
+        elif status == 422:  # already exists
+            status_p, _ = _request(
+                "PATCH",
+                f"/repos/{REPO}/labels/{urllib.parse.quote(name)}",
+                token,
+                {"new_name": name, "color": color, "description": desc},
+            )
+            if status_p == 200:
+                print(f"  ~ updated existing label {name}")
+            else:
+                print(f"  ! could not update label {name} (status {status_p})")
+        else:
+            print(f"  ! error creating label {name}: status {status} body {body}")
+            sys.exit(2)
+
+# ---------- Issue bodies ----------
+
+TRACK_A_BODY = """## Sprint 2 Feedback — {entry_id} {entry_title}
+
+This issue collects **qualitative feedback** on the refreshed **{entry_id} {entry_title}** entry. \
+Submit your **Importance** and **Clarity** scores via the Sprint 2 Google Form (single ballot covering both tracks).
+
+- **Vote**: {form_url} — page through to the **{entry_id}** section
+- **Read the draft**: https://github.com/{repo}/blob/main/2026/{file}
+- **Voting closes**: May 18, 2026 at 23:59 UTC
+- **Code of Conduct**: https://owasp.org/www-policy/operational/code-of-conduct
+
+### Scoring rubric
+
+- **Importance** (1–5): How critical is this risk to LLM application security in 2026?
+- **Clarity** (1–5): How clearly does the entry describe the risk and its mitigations?
+
+### How to comment
+
+Reply to this issue with feedback specific to **{entry_id}**. Use one comment per topic so the working group can triage cleanly. Format we like:
+
+```
+Section: <which section of the entry>
+Issue: <what is wrong, missing, or unclear>
+Proposed change: <your suggested fix or addition>
+Evidence: <CVE, paper, incident, or research note ID if applicable>
+```
+
+### Out of scope here
+
+- Cross-cutting comments → use [Discussions]({discussions_url})
+- Questions about Track B candidates → comment on the relevant Track B issue
+- Process or governance questions → comment in [Discussions]({discussions_url})
+
+### Triage
+
+Working group entry leads classify each comment within 48 hours as:
+- **actionable** — feeds Sprint 3 revision
+- **clarification** — requires reply, not action
+- **out-of-scope** — closed with redirect
+
+Sprint 3 begins May 18 with this issue's triage as input.
+"""
+
+TRACK_B_BODY = """## Sprint 2 Feedback — {entry_title}
+
+This issue collects **qualitative feedback** on the **{entry_title}** new candidate entry. \
+Submit your **Importance**, **Clarity**, and **Distinctness** scores via the Sprint 2 Google Form (single ballot covering both tracks).
+
+- **Vote**: {form_url} — page through to the Track B section, then to **{entry_title}**
+- **Read the draft**: https://github.com/{repo}/blob/main/2026/new_entry_candidates/{file}
+- **Voting closes**: May 18, 2026 at 23:59 UTC
+- **Code of Conduct**: https://owasp.org/www-policy/operational/code-of-conduct
+
+### Scoring rubric
+
+- **Importance** (1–5): How critical is this risk to LLM application security in 2026?
+- **Clarity** (1–5): How clearly does the candidate describe the risk and mitigations?
+- **Distinctness** (1–5): Is this materially different from existing entries (LLM01–LLM10), or could it be merged into one of them?
+
+### Why Distinctness matters
+
+Sprint 3 cuts 8 candidates down to 5. A high-Importance candidate that overlaps heavily with an existing entry is a merge target, not a standalone winner. Distinctness scores let the working group make defensible cut, keep, or merge calls.
+
+### How to comment
+
+Reply to this issue with feedback specific to **{entry_title}**. Use one comment per topic so the working group can triage cleanly. Format we like:
+
+```
+Section: <which section of the candidate>
+Issue: <what is wrong, missing, unclear, or duplicative>
+Proposed change: <your suggested fix, addition, or merge target>
+Overlaps with: <existing entry LLM01–LLM10 if applicable>
+Evidence: <CVE, paper, incident, or research note ID if applicable>
+```
+
+### Out of scope here
+
+- Cross-cutting comments → use [Discussions]({discussions_url})
+- Comments on existing entries (LLM01–LLM10) → comment on the relevant Track A issue
+- Process or governance questions → comment in [Discussions]({discussions_url})
+
+### Triage
+
+Working group entry leads classify each comment within 48 hours as:
+- **actionable** — feeds Sprint 3 revision or merge decision
+- **clarification** — requires reply, not action
+- **out-of-scope** — closed with redirect
+
+Sprint 3 begins May 18 with this issue's triage as input.
+"""
+
+DISCUSSIONS_URL = f"https://github.com/{REPO}/discussions"
+
+# ---------- Issue creation ----------
+
+def render_track_a(entry: dict, form_url: str) -> tuple[str, str]:
+    title = f"[Track A] Feedback: {entry['id']} — {entry['title']}"
+    body = TRACK_A_BODY.format(
+        entry_id=entry["id"],
+        entry_title=entry["title"],
+        file=entry["file"],
+        repo=REPO,
+        form_url=form_url,
+        discussions_url=DISCUSSIONS_URL,
+    )
+    return title, body
+
+def render_track_b(entry: dict, form_url: str) -> tuple[str, str]:
+    title = f"[Track B] Feedback: {entry['title']}"
+    body = TRACK_B_BODY.format(
+        entry_title=entry["title"],
+        file=entry["file"],
+        repo=REPO,
+        form_url=form_url,
+        discussions_url=DISCUSSIONS_URL,
+    )
+    return title, body
+
+def post_issue(title: str, body: str, labels: list[str], token: str, dry_run: bool) -> int | None:
+    if dry_run:
+        print(f"  [dry-run] would create issue: {title}")
+        print(f"             labels: {labels}")
+        return None
+    status, response = _request("POST", f"/repos/{REPO}/issues", token, {
+        "title": title, "body": body, "labels": labels,
+    })
+    if status == 201:
+        num = response.get("number")
+        url = response.get("html_url")
+        print(f"  + #{num} {title}")
+        print(f"     {url}")
+        return num
+    print(f"  ! failed to create {title!r}: status {status} body {response}")
+    return None
+
+# ---------- Main ----------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create Sprint 2 feedback issues.")
+    parser.add_argument("--form-url", required=True, help="Published URL for the Sprint 2 Google Form (single ballot, both tracks)")
+    parser.add_argument("--dry-run", action="store_true", help="Render but do not post.")
+    parser.add_argument("--issues-file", default=str(ISSUES_PATH), help="Path to issues.json")
+    parser.add_argument("--skip-labels", action="store_true", help="Skip the label upsert step.")
+    args = parser.parse_args()
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token and not args.dry_run:
+        print("ERROR: set GH_TOKEN or GITHUB_TOKEN before running.", file=sys.stderr)
+        return 1
+
+    issues_file = Path(args.issues_file)
+    if not issues_file.exists():
+        print(f"ERROR: issues file not found at {issues_file}", file=sys.stderr)
+        return 1
+
+    config = json.loads(issues_file.read_text())
+    print(f"OWASP Top 10 LLM 2026 — Sprint 2 issue creator (dry_run={args.dry_run})")
+    print(f"  repo:     {REPO}")
+    print(f"  form url: {args.form_url}")
+    print(f"  track A:  {len(config['track_a'])} issues")
+    print(f"  track B:  {len(config['track_b'])} issues")
+
+    if not args.skip_labels:
+        ensure_labels(config["labels"], token or "", args.dry_run)
+
+    print("[track-a] creating issues")
+    for entry in config["track_a"]:
+        title, body = render_track_a(entry, args.form_url)
+        post_issue(title, body, ["sprint-2", "track-a", "feedback", entry["id"]],
+                   token or "", args.dry_run)
+        if not args.dry_run:
+            time.sleep(RATE_PAUSE_SEC)
+
+    print("[track-b] creating issues")
+    for entry in config["track_b"]:
+        title, body = render_track_b(entry, args.form_url)
+        post_issue(title, body, ["sprint-2", "track-b", "feedback", entry["id"]],
+                   token or "", args.dry_run)
+        if not args.dry_run:
+            time.sleep(RATE_PAUSE_SEC)
+
+    print("done.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/2026/polling/scripts/issues.json
+++ b/2026/polling/scripts/issues.json
@@ -1,0 +1,69 @@
+{
+  "_meta": {
+    "version": "1.1",
+    "owner": "rock@rockcyber.ai",
+    "repo": "GenAI-Security-Project/GenAI-LLM-Top10",
+    "voting_close": "May 18, 2026 at 23:59 UTC",
+    "form": {
+      "published_url": "https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform",
+      "short_url":     "https://forms.gle/jFmqZF1R6k9gCEfi6",
+      "form_id":       "1lNZHaqUQC_A9DJeSy9JJ1FQkzE1T-lA92vbJLoE6K_k",
+      "generated":     "May 4, 2026",
+      "covers_tracks": ["A", "B"]
+    },
+    "discussion": {
+      "url":      "https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/discussions/54",
+      "number":   54,
+      "category": "Announcements",
+      "pinned":   true,
+      "created":  "May 4, 2026"
+    },
+    "notes": "All 18 issues are pre-rendered. Run create_issues.py with --form-url pointing at the published_url above. The script posts to the GitHub API. One Form URL covers both tracks; voters land on the same URL from any issue and navigate to the relevant entry section. The form_id is the Drive ID — pass it to the aggregation pipeline to read the linked response Sheet."
+  },
+  "labels": [
+    {"name": "sprint-2",  "color": "0E8A16", "description": "Sprint 2 — Community Review and Voting (May 4–18, 2026)"},
+    {"name": "track-a",   "color": "1D76DB", "description": "Track A — feedback on existing Top 10 entries"},
+    {"name": "track-b",   "color": "5319E7", "description": "Track B — feedback on new candidate entries"},
+    {"name": "feedback",  "color": "FBCA04", "description": "Community feedback on a specific entry"},
+    {"name": "LLM01",     "color": "C5DEF5", "description": "LLM01 Prompt Injection"},
+    {"name": "LLM02",     "color": "C5DEF5", "description": "LLM02 Sensitive Information Disclosure"},
+    {"name": "LLM03",     "color": "C5DEF5", "description": "LLM03 Supply Chain"},
+    {"name": "LLM04",     "color": "C5DEF5", "description": "LLM04 Data and Model Poisoning"},
+    {"name": "LLM05",     "color": "C5DEF5", "description": "LLM05 Improper Output Handling"},
+    {"name": "LLM06",     "color": "C5DEF5", "description": "LLM06 Excessive Agency"},
+    {"name": "LLM07",     "color": "C5DEF5", "description": "LLM07 System Prompt Leakage"},
+    {"name": "LLM08",     "color": "C5DEF5", "description": "LLM08 Vector and Embedding Weaknesses"},
+    {"name": "LLM09",     "color": "C5DEF5", "description": "LLM09 Misinformation"},
+    {"name": "LLM10",     "color": "C5DEF5", "description": "LLM10 Unbounded Consumption"},
+    {"name": "TB-CFAS",   "color": "D4C5F9", "description": "Compositional Fine-Tuning Alignment Subversion"},
+    {"name": "TB-CMSB",   "color": "D4C5F9", "description": "Cross-Modal Safety Bypass"},
+    {"name": "TB-ITSC",   "color": "D4C5F9", "description": "Inference-Time Side-Channel Disclosure"},
+    {"name": "TB-MCPX",   "color": "D4C5F9", "description": "MCP Tool Interface Exploitation"},
+    {"name": "TB-MMIS",   "color": "D4C5F9", "description": "Model Misalignment"},
+    {"name": "TB-MSDA",   "color": "D4C5F9", "description": "Model Scheming and Deceptive Alignment"},
+    {"name": "TB-SICG",   "color": "D4C5F9", "description": "Systemic Insecure Code Generation"},
+    {"name": "TB-WLLA",   "color": "D4C5F9", "description": "Weaponized LLM Abuse"}
+  ],
+  "track_a": [
+    {"id": "LLM01", "title": "Prompt Injection",                       "file": "LLM01_PromptInjection.md"},
+    {"id": "LLM02", "title": "Sensitive Information Disclosure",       "file": "LLM02_SensitiveInformationDisclosure.md"},
+    {"id": "LLM03", "title": "Supply Chain",                           "file": "LLM03_SupplyChain.md"},
+    {"id": "LLM04", "title": "Data and Model Poisoning",               "file": "LLM04_DataModelPoisoning.md"},
+    {"id": "LLM05", "title": "Improper Output Handling",               "file": "LLM05_ImproperOutputHandling.md"},
+    {"id": "LLM06", "title": "Excessive Agency",                       "file": "LLM06_ExcessiveAgency.md"},
+    {"id": "LLM07", "title": "System Prompt Leakage",                  "file": "LLM07_SystemPromptLeakage.md"},
+    {"id": "LLM08", "title": "Vector and Embedding Weaknesses",        "file": "LLM08_VectorAndEmbeddingWeaknesses.md"},
+    {"id": "LLM09", "title": "Misinformation",                         "file": "LLM09_Misinformation.md"},
+    {"id": "LLM10", "title": "Unbounded Consumption",                  "file": "LLM10_UnboundedConsumption.md"}
+  ],
+  "track_b": [
+    {"id": "TB-CFAS", "title": "Compositional Fine-Tuning Alignment Subversion", "file": "compositional-finetuning-alignment-subversion.md"},
+    {"id": "TB-CMSB", "title": "Cross-Modal Safety Bypass",                       "file": "cross-modal-safety-bypass.md"},
+    {"id": "TB-ITSC", "title": "Inference-Time Side-Channel Disclosure",          "file": "inference-time-side-channel-disclosure.md"},
+    {"id": "TB-MCPX", "title": "MCP Tool Interface Exploitation",                 "file": "mcp-tool-interface-exploitation.md"},
+    {"id": "TB-MMIS", "title": "Model Misalignment",                              "file": "model-misalignment.md"},
+    {"id": "TB-MSDA", "title": "Model Scheming and Deceptive Alignment",          "file": "model-scheming-and-deceptive-alignment.md"},
+    {"id": "TB-SICG", "title": "Systemic Insecure Code Generation",               "file": "systemic-insecure-code-generation.md"},
+    {"id": "TB-WLLA", "title": "Weaponized LLM Abuse",                            "file": "weaponized-llm-abuse.md"}
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `2026/polling/` — the form blueprint, the Apps Script generator (`create_form.gs`), and the issue creator (`create_issues.py` + `issues.json`) used to drive Sprint 2 community voting.
- Moves the issue templates to `.github/ISSUE_TEMPLATE/` (where GitHub auto-discovers them) so contributors can open Track A / Track B feedback issues directly from the **Issues → New issue** picker.
- Expands root `.gitignore` to cover internal sprint comms drafts (`2026/polling/comms/`), the Apps Script execution log, `__pycache__/`, `*.pyc`, and `.DS_Store`.
- Strips the Google Form **Edit URL** from every committed file; the **Form ID** is retained because the downstream aggregation pipeline keys on it.

Sprint 2 is already live: 18 feedback issues (#36–#53) and the pinned announcement (#54) reference the assets in this PR.

## Test plan

- [ ] CI: `markdownlint-cli2 "**/*.md"` passes
- [ ] `.github/ISSUE_TEMPLATE/` shows both feedback templates in the **New issue** picker on the repo
- [ ] `gh api repos/GenAI-Security-Project/GenAI-LLM-Top10/contents/.github/ISSUE_TEMPLATE` returns the three files
- [ ] `grep -rn "/edit" 2026/polling/` returns no Google Forms edit URLs
- [ ] No `comms/` content appears in the diff (gitignored)