### PR TITLE
codeowners: route 2026 entry PRs to entry leads

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,18 @@
 # CODEOWNERS
-# Every PR to main requires approval from a repo admin listed here.
+# Every PR to main requires approval from a code owner of every changed path.
+# The default rule below covers everything; the per-entry rules below route
+# 2026/LLM0X_*.md PRs to that entry's leads (see 2026/Leads/ for the source list).
 
 *       @rossja @rocklambros @virtualsteve-star
+
+# 2026 entry leads
+2026/LLM01_*    @cybershujin
+2026/LLM02_*    @emmanuelgjr @kenhuangus
+2026/LLM03_*    @jsotiro @stefanoamorelli
+2026/LLM04_*    @sjeswani28 @owasprox @anithadakamarri-sudo
+2026/LLM05_*    @ricokomenda @GTKlondike
+2026/LLM06_*    @rot169
+2026/LLM07_*    @atleung @zoh-labs @vingiarrusso
+2026/LLM08_*    @S3DFX-CYBER @arshi016
+2026/LLM09_*    @virtualsteve-star
+2026/LLM10_*    @Sahil-Mehta881 @saikishu


### PR DESCRIPTION
## Summary

Adds per-entry CODEOWNERS rules so PRs touching `2026/LLM0X_*` files auto-route review requests to that entry's leads, instead of only the three repo-wide admins. Fixes the routing gap where Sprint 1 / 2 entry PRs were only seen by admins, and entry leads had to be tagged manually.

| Entry | Leads |
|---|---|
| LLM01 Prompt Injection | @cybershujin |
| LLM02 Sensitive Information Disclosure | @emmanuelgjr @kenhuangus |
| LLM03 Supply Chain Vulnerabilities | @jsotiro @stefanoamorelli |
| LLM04 Data and Model Poisoning | @sjeswani28 @owasprox @anithadakamarri-sudo |
| LLM05 Improper Output Handling | @ricokomenda @GTKlondike |
| LLM06 Excessive Agency | @rot169 |
| LLM07 System Prompt Leakage | @atleung @zoh-labs @vingiarrusso |
| LLM08 Vector and Embedding Weaknesses | @S3DFX-CYBER @arshi016 |
| LLM09 Misinformation | @virtualsteve-star |
| LLM10 Unbounded Consumption | @Sahil-Mehta881 @saikishu |

The default `*` rule (admins on everything) is preserved; per-entry rules layer on top. GitHub uses last-match-wins precedence, so `2026/LLM01_*` PRs route to LLM01 leads. Admins can still approve as a second reviewer or use admin merge for the rare unblock case.

## Test plan

- [ ] Verify in the **Settings → Code owners** UI that each `2026/LLM0X_*` rule resolves to the listed handles
- [ ] On the next entry PR (any open one), confirm GitHub auto-requests review from the matching entry leads, not just admins
- [ ] markdownlint CI passes (no markdown files touched)