### PR TITLE
polling: align Track A/B with CONTRIBUTING.md and bundle Sprint 2 scaffolding

### DIFF
--- a/2026/polling/.github/ISSUE_TEMPLATE/config.yml
+++ b/2026/polling/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Vote (single ballot, both tracks)
+    url: https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform
+    about: Score Importance and Clarity for the 10 existing entries, plus Distinctness for the 8 new candidates. Single submission. Estimated 10 minutes if you score every entry.
+  - name: General discussion (Sprint 2)
+    url: https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/discussions
+    about: For comments not tied to a specific entry. Cross-cutting questions, proposed new entries, process feedback.
+  - name: OWASP Top 10 for LLM project page
+    url: https://genai.owasp.org/llm-top-10/
+    about: Project background, charter, and Sprint 2 timeline.

--- a/2026/polling/.github/ISSUE_TEMPLATE/feedback-track-a.yml
+++ b/2026/polling/.github/ISSUE_TEMPLATE/feedback-track-a.yml
@@ -1,0 +1,118 @@
+name: Sprint 2 Feedback — Track A (New Candidate Entry)
+description: Comment on a new candidate entry. Use the linked Google Form for Importance, Clarity, and Distinctness scores.
+title: "[Track A] Feedback: <CANDIDATE_TITLE>"
+labels:
+  - sprint-2
+  - track-a
+  - feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Sprint 2 Community Review — Track A
+
+        Use this issue to leave **qualitative feedback** on this candidate. Use the **Google Form** to submit your **Importance**, **Clarity**, and **Distinctness** scores. One ballot covers all 18 entries (both tracks).
+
+        - Vote: https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform — page through to the Track A section, then to this candidate
+        - Voting closes: **May 18, 2026 at 23:59 UTC**
+        - Code of Conduct: [OWASP Code of Conduct](https://owasp.org/www-policy/operational/code-of-conduct)
+
+        ### Scoring rubric
+
+        - **Importance** (1–5): How critical is this risk to LLM application security in 2026?
+        - **Clarity** (1–5): How clearly does the candidate describe the risk and mitigations?
+        - **Distinctness** (1–5): Is this materially different from existing entries (LLM01–LLM10), or could it be merged into one of them?
+
+        ### Why Distinctness matters
+
+        Sprint 3 cuts 8 candidates down to 5. A high-Importance candidate that overlaps heavily with an existing entry is a merge target, not a standalone winner. Distinctness scores let the working group make defensible cut/keep/merge calls.
+
+        ### What good feedback looks like
+
+        - Specific to this candidate (not the Top 10 as a whole)
+        - Names the existing entry (LLM01–LLM10) this candidate overlaps with, if any
+        - References a citation, CVE, incident, or research note when possible
+        - Proposes language for definitions, examples, or mitigations
+
+  - type: input
+    id: candidate_id
+    attributes:
+      label: Candidate ID
+      description: The TA-XXXX label for this candidate (e.g., TA-MCPX).
+      placeholder: TA-MCPX
+    validations:
+      required: true
+
+  - type: dropdown
+    id: feedback_type
+    attributes:
+      label: Feedback category
+      description: Pick the closest match. Use one issue per category if you have multiple types of feedback.
+      options:
+        - Definition or scope
+        - Common examples
+        - Prevention or mitigation strategies
+        - Attack scenarios
+        - Reference or supporting research
+        - Distinctness — overlaps with existing entry
+        - Distinctness — should be merged into another candidate
+        - Editorial (clarity, formatting, terminology)
+        - Recommend dropping from consideration
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: overlap_with
+    attributes:
+      label: If this overlaps with an existing entry, which one?
+      description: Optional. Only fill if you flagged Distinctness as your feedback category.
+      options:
+        - "N/A — this is distinct"
+        - LLM01 Prompt Injection
+        - LLM02 Sensitive Information Disclosure
+        - LLM03 Supply Chain
+        - LLM04 Data and Model Poisoning
+        - LLM05 Improper Output Handling
+        - LLM06 Excessive Agency
+        - LLM07 System Prompt Leakage
+        - LLM08 Vector and Embedding Weaknesses
+        - LLM09 Misinformation
+        - LLM10 Unbounded Consumption
+        - Multiple existing entries (specify in body)
+    validations:
+      required: false
+
+  - type: textarea
+    id: feedback_body
+    attributes:
+      label: Your feedback
+      description: Be specific. Quote the section or phrase you are referring to. Propose alternative language where possible.
+      placeholder: |
+        Section: <which section of the candidate>
+        Issue: <what is wrong, missing, unclear, or duplicative>
+        Proposed change: <your suggested fix, addition, or merge target>
+        Evidence: <CVE, paper, incident, or research note ID if applicable>
+    validations:
+      required: true
+
+  - type: input
+    id: github_handle
+    attributes:
+      label: GitHub username (optional)
+      description: For voters who also commented here. Helps cross-validate engagement against the ballot data.
+      placeholder: "@your-handle"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Acknowledgments
+      options:
+        - label: I have read the candidate entry I am commenting on.
+          required: true
+        - label: I agree to abide by the OWASP Code of Conduct.
+          required: true
+        - label: I understand my comment will be public and may be quoted in Sprint 3 working notes.
+          required: true

--- a/2026/polling/.github/ISSUE_TEMPLATE/feedback-track-b.yml
+++ b/2026/polling/.github/ISSUE_TEMPLATE/feedback-track-b.yml
@@ -1,0 +1,91 @@
+name: Sprint 2 Feedback — Track B (Existing Entry)
+description: Comment on a refreshed existing Top 10 entry. Use the linked Google Form for Importance and Clarity scores.
+title: "[Track B] Feedback: <ENTRY_ID> — <ENTRY_TITLE>"
+labels:
+  - sprint-2
+  - track-b
+  - feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Sprint 2 Community Review — Track B
+
+        Use this issue to leave **qualitative feedback** on the refreshed entry. Use the **Google Form** to submit your **Importance** and **Clarity** scores. One ballot covers all 18 entries (both tracks). The form and these issues are linked but separate by design.
+
+        - Vote: https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform — page through to the relevant Track B entry
+        - Voting closes: **May 18, 2026 at 23:59 UTC**
+        - Code of Conduct: [OWASP Code of Conduct](https://owasp.org/www-policy/operational/code-of-conduct)
+
+        ### Scoring rubric
+
+        - **Importance** (1–5): How critical is this risk to LLM application security in 2026?
+        - **Clarity** (1–5): How clearly does the entry describe the risk and its mitigations?
+
+        ### What good feedback looks like
+
+        - Specific to this entry (not the Top 10 as a whole)
+        - References a definition, example, or mitigation that is missing, wrong, or outdated
+        - Includes a citation, CVE, incident, or research finding when possible
+        - Proposes language, not just objections
+
+  - type: input
+    id: entry_id
+    attributes:
+      label: Entry ID
+      description: Confirm the entry you are commenting on (e.g., LLM01).
+      placeholder: LLM01
+    validations:
+      required: true
+
+  - type: dropdown
+    id: feedback_type
+    attributes:
+      label: Feedback category
+      description: Pick the closest match. Use one issue per category if you have multiple types of feedback.
+      options:
+        - Definition or scope
+        - Common examples
+        - Prevention or mitigation strategies
+        - Attack scenarios
+        - Reference or supporting research
+        - Editorial (clarity, formatting, terminology)
+        - Suggest merging with another entry
+        - Suggest splitting into multiple entries
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: feedback_body
+    attributes:
+      label: Your feedback
+      description: Be specific. Quote the section or phrase you are referring to. Propose alternative language where possible.
+      placeholder: |
+        Section: <which section of the entry>
+        Issue: <what is wrong, missing, or unclear>
+        Proposed change: <your suggested fix or addition>
+        Evidence: <CVE, paper, incident, or research note ID if applicable>
+    validations:
+      required: true
+
+  - type: input
+    id: github_handle
+    attributes:
+      label: GitHub username (optional)
+      description: For voters who also commented here. Helps cross-validate engagement against the ballot data.
+      placeholder: "@your-handle"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Acknowledgments
+      options:
+        - label: I have read the entry I am commenting on.
+          required: true
+        - label: I agree to abide by the OWASP Code of Conduct.
+          required: true
+        - label: I understand my comment will be public and may be quoted in Sprint 3 working notes.
+          required: true

--- a/2026/polling/.gitignore
+++ b/2026/polling/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+.DS_Store
+.env

--- a/2026/polling/README.md
+++ b/2026/polling/README.md
@@ -16,8 +16,8 @@ polling/
 ├── .gitignore
 ├── .github/
 │   └── ISSUE_TEMPLATE/
-│       ├── feedback-track-a.yml           # issue form for existing-entry feedback
-│       ├── feedback-track-b.yml           # issue form for candidate-entry feedback
+│       ├── feedback-track-b.yml           # issue form for existing-entry feedback
+│       ├── feedback-track-a.yml           # issue form for candidate-entry feedback
 │       └── config.yml                     # disables blank issues, adds vote link
 ├── forms/
 │   ├── create_form.gs                     # Apps Script: builds the Sprint 2 Google Form
@@ -39,6 +39,7 @@ Form was generated on May 4, 2026 from `forms/create_form.gs` running under Rock
 
 - **Published URL** (used by GitHub issues): https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform
 - **Short URL** (use for LinkedIn, Slack, mailing list): https://forms.gle/jFmqZF1R6k9gCEfi6
+- **Edit URL** (working group only): https://docs.google.com/forms/d/1lNZHaqUQC_A9DJeSy9JJ1FQkzE1T-lA92vbJLoE6K_k/edit
 - **Form ID**: `1lNZHaqUQC_A9DJeSy9JJ1FQkzE1T-lA92vbJLoE6K_k`
 
 The Form ID feeds the aggregation pipeline (it identifies the linked response Sheet). All values are stored in `scripts/issues.json` under `_meta.form` for traceability.
@@ -51,7 +52,7 @@ Copy `polling/.github/ISSUE_TEMPLATE/*.yml` to `.github/ISSUE_TEMPLATE/` in the 
 
 ### 3. Create the 18 feedback issues — **DONE**
 
-Issues fired May 4, 2026 via the Python script (`create_issues.py`) running under Rock's gh CLI auth. 22 labels upserted, 10 Track A issues, 8 Track B issues. Filter: https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/issues?q=is%3Aissue+label%3Asprint-2
+Issues fired May 4, 2026 via the Python script (`create_issues.py`) running under Rock's gh CLI auth. 22 labels upserted, 10 Track B issues, 8 Track A issues. Filter: https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/issues?q=is%3Aissue+label%3Asprint-2
 
 If you ever need to re-run (e.g., to add a candidate mid-sprint):
 
@@ -77,11 +78,11 @@ Body sourced from `comms/github_discussion_pinned.md`. The Discussion is the FAQ
 
 ## Why one combined form
 
-Single URL to promote, single captive audience. A voter who finishes the existing entries (Track A) rolls naturally into the new candidates (Track B) instead of needing to remember a second link. Track B participation rises. Comms simplify.
+Single URL to promote, single captive audience. A voter who finishes the existing entries (Track B) rolls naturally into the new candidates (Track A) instead of needing to remember a second link. Track A participation rises. Comms simplify.
 
-The cost is voter fatigue mid-form. All Likert questions are optional, so drop-off is graceful and tracked as a metric in aggregation. Per-entry response rate proxies completion. The aggregation pipeline distinguishes "completed Track A only" from "completed both" so partial ballots still count.
+The cost is voter fatigue mid-form. All Likert questions are optional, so drop-off is graceful and tracked as a metric in aggregation. Per-entry response rate proxies completion. The aggregation pipeline distinguishes "completed Track B only" from "completed both" so partial ballots still count.
 
-Tracks remain analytically separate. Question titles tag every score with its entry ID (`LLM01 — Importance`, `TB-MCPX — Distinctness`), so the aggregation pipeline splits the data cleanly.
+Tracks remain analytically separate. Question titles tag every score with its entry ID (`LLM01 — Importance`, `TA-MCPX — Distinctness`), so the aggregation pipeline splits the data cleanly.
 
 ## Voter integrity
 
@@ -118,8 +119,8 @@ Adding entries mid-sprint resets voting baselines. Avoid if possible.
 
 | Decision | Rationale |
 | --- | --- |
-| Single combined Form (Track A then Track B) | One URL to promote. Captive audience rolls from familiar existing entries into new candidates. Higher Track B participation. |
-| Track B includes Distinctness Likert | Sprint 3 cuts 8→5. High-Importance candidates that overlap heavily with existing entries are merge targets, not standalone winners. Distinctness gives a defensible cut/keep/merge signal. |
+| Single combined Form (Track B then Track A) | One URL to promote. Captive audience rolls from familiar existing entries into new candidates. Higher Track A participation. |
+| Track A includes Distinctness Likert | Sprint 3 cuts 8→5. High-Importance candidates that overlap heavily with existing entries are merge targets, not standalone winners. Distinctness gives a defensible cut/keep/merge signal. |
 | All Likerts optional, none required | Forced votes from unqualified voters add noise. Skip rate is a deliberate metric. |
 | Each entry on its own page | Progress visible. Voters can stop and resume. |
 | GitHub for comments, Form for scores | Comments need durability and version history (GitHub). Structured numeric data needs clean export (Form → Sheet). Two systems, linked, each playing to its strength. |
@@ -129,7 +130,7 @@ Adding entries mid-sprint resets voting baselines. Avoid if possible.
 ## Known limitations
 
 - **Section deep-linking**: Google Forms always opens at page 1. Voters arriving from a specific entry's GitHub issue still see "About You" first and have to page through. The issue body explains the navigation.
-- **Order bias**: Track A always precedes Track B. Each track lists entries in canonical order. Voters who fatigue mid-form score later entries less generously. Aggregation reports per-entry response rate to flag.
+- **Order bias**: Track B always precedes Track A. Each track lists entries in canonical order. Voters who fatigue mid-form score later entries less generously. Aggregation reports per-entry response rate to flag.
 - **Drop-off mid-form**: 19 pages is long. Aggregation tracks completion per entry as the participation signal.
 - **Workspace gating**: native one-response-per-user enforcement requires Workspace. Email dedup compensates.
 - **Brigading risk**: a public Form is a brigading target. Anomaly detection compensates.

--- a/2026/polling/RUNBOOK_TOMORROW.md
+++ b/2026/polling/RUNBOOK_TOMORROW.md
@@ -1,0 +1,464 @@
+# Tomorrow Morning Runbook: Sync, Refresh, Launch
+
+Owner: Rock Lambros
+When: Morning of May 5, 2026, before any LinkedIn or Slack posts go out.
+Total time: about 30 minutes start to finish.
+
+This is your runbook. It assumes you'll let Claude Code do anything against GitHub via the gh CLI it already has. Phases that need a browser (Apps Script, posting to LinkedIn) are flagged explicitly.
+
+Each phase has a clear checkpoint. Stop between phases if anything looks wrong.
+
+## How to use this document
+
+1. Open one terminal window.
+2. Open one Chrome/browser tab (you'll need it for Apps Script and posting comms).
+3. For each phase below, copy the **command** or **prompt** in the code block and paste it where indicated.
+4. Read the output carefully before moving to the next phase.
+
+When the doc says "**Claude Code prompt**", paste the entire code block into a Claude Code session. Claude Code uses your existing gh CLI auth — no token paste required.
+
+When the doc says "**Browser**", switch to your browser tab and do exactly what's described.
+
+## Files and locations referenced in this runbook
+
+| Thing | Where |
+| --- | --- |
+| Local repo | `/Users/klambros/github_projects/GenAI-LLM-Top10` |
+| Sync script | `2026/polling/scripts/sync_sprint2.py` |
+| Issue creation script (fallback) | `2026/polling/scripts/create_issues.py` |
+| Form Apps Script source | `2026/polling/forms/create_form.gs` |
+| Live registry (write target) | `2026/polling/scripts/issues.json` |
+| Pinned Discussion | https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/discussions/54 |
+| Form Edit URL | https://docs.google.com/forms/d/1lNZHaqUQC_A9DJeSy9JJ1FQkzE1T-lA92vbJLoE6K_k/edit |
+| Form Published URL | https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform |
+| Form Short URL | https://forms.gle/jFmqZF1R6k9gCEfi6 |
+| Apps Script editor | https://script.google.com |
+
+# Phase 0: Open Claude Code
+
+**Terminal:**
+
+```bash
+cd /Users/klambros/github_projects/GenAI-LLM-Top10
+claude
+```
+
+You should now be in a Claude Code session with the working directory set to the repo root.
+
+# Phase 1: Pre-flight
+
+Verifies gh CLI auth, pulls latest main so the eventual `git push` doesn't conflict, and shows the current registry baseline so you know what state you're starting from.
+
+**Claude Code prompt:**
+
+```
+Pre-flight check for the OWASP Sprint 2 sync. Do all of these and STOP. Do NOT run the sync yet.
+
+1. Verify gh CLI is authenticated:
+   gh auth status
+
+   Tell me what you see. If "not logged in", stop and tell me to run `gh auth login`.
+
+2. Switch to main and pull:
+   git checkout main
+   git pull origin main
+
+   Tell me if the pull succeeded and whether anything came down.
+
+3. Show the current Track B and Track A entry counts in the LOCAL registry:
+   python3 -c "
+   import json
+   d = json.load(open('2026/polling/scripts/issues.json'))
+   print('Track B:', len(d['track_b']))
+   print('Track A:', len(d['track_a']))
+   for e in d['track_b']: print(' ', e['id'], e['title'])
+   for e in d['track_a']: print(' ', e['id'], e['title'])
+   "
+
+4. Print 'PHASE 1 COMPLETE — READY FOR PHASE 2'.
+
+STOP. Do not proceed to any sync action.
+```
+
+**Checkpoint:** You should see gh auth status as logged in, a clean `git pull`, and a list of the current 18 entries. If anything errors out, fix that before moving on.
+
+# Phase 2: Preview the diff
+
+Reads everything from remote main at run time. Shows you exactly what would change. Writes nothing, fires nothing.
+
+**Claude Code prompt:**
+
+```
+Run a dry-run sync against the OWASP Sprint 2 repo. Show me the full output. Do NOT apply.
+
+Steps:
+1. Set GH_TOKEN from gh CLI:
+   export GH_TOKEN=$(gh auth token)
+
+2. Run the sync in dry-run mode:
+   python3 2026/polling/scripts/sync_sprint2.py --dry-run
+
+3. After it finishes, summarize for me:
+   - How many entries are NEW in Track B and Track A (from the [+] NEW sections)
+   - How many entries CHANGED (file rename or title edit, from the [~] CHANGED sections)
+   - How many entries REMOVED (warnings only, from the [-] REMOVED section)
+   - Total new GitHub issues that would fire
+   - Total existing GitHub issues that would be PATCHed
+
+4. Print 'PHASE 2 COMPLETE — REVIEW THE DIFF, THEN GIVE ME GO TO PROCEED'.
+
+STOP. Do not apply. Wait for my explicit "go".
+```
+
+**Checkpoint:** Read Claude Code's summary carefully.
+
+Things to check:
+
+- New candidate IDs look reasonable (auto-generated as initials of the filename slug)
+- Changed entries match what the team told you they were updating
+- No removals you weren't expecting
+- Issue counts make sense
+
+**If anything is off**, stop here and either fix the underlying repo state or tell me what's weird. Do not proceed.
+
+**If everything is right**, type "go" or "proceed" in Claude Code and continue to Phase 3.
+
+# Phase 3: Apply the sync
+
+Updates `issues.json`, PATCHes existing GitHub issues, creates new ones, commits, pushes.
+
+**Claude Code prompt:**
+
+```
+Apply the OWASP Sprint 2 sync. Run the same script without --dry-run. Then commit and push the registry. Walk me through the output.
+
+Steps:
+1. Make sure GH_TOKEN is still exported (re-run if needed):
+   export GH_TOKEN=$(gh auth token)
+
+2. Run the sync for real:
+   python3 2026/polling/scripts/sync_sprint2.py
+
+3. Show me the output, especially the SUMMARY block at the end. Tell me:
+   - How many existing issues were updated (PATCHed)
+   - How many new issues were created
+   - The list of entry IDs in each category
+
+4. Show the git diff of issues.json (just the file list and stat, not the full contents):
+   git diff --stat 2026/polling/scripts/issues.json
+
+5. Commit and push the registry:
+   git add 2026/polling/scripts/issues.json
+   git commit -m "Sprint 2: sync entry registry against remote state"
+   git push origin main
+
+6. Tell me the commit SHA and confirm the push succeeded.
+
+7. Print 'PHASE 3 COMPLETE — REGISTRY ON MAIN, ISSUES UPDATED, READY FOR FORM REFRESH'.
+
+STOP after the push. Do not touch the form yet.
+```
+
+**Checkpoint:** You should see:
+
+- Sync summary showing the right number of updates and creates
+- git diff stat showing `issues.json` modified
+- Commit succeeded
+- Push succeeded
+
+**If the push is rejected** (someone else pushed first), Claude Code will tell you. The fix is `git pull --rebase`, resolve any conflicts on `issues.json` (yours wins; the script regenerated it), then push again.
+
+# Phase 4: Refresh the Google Form (browser)
+
+This is the only phase that requires the browser. About 3 minutes.
+
+**Browser:**
+
+### 4.1 — Open Apps Script
+
+Go to https://script.google.com.
+
+You should see your existing project (probably named "OWASP LLM Top 10 — Sprint 2 Voting Form" or similar). Click it.
+
+### 4.2 — Make sure the script is current
+
+Open `2026/polling/forms/create_form.gs` from your local repo in any text editor (or open it in the GitHub web view). Compare against what's in Apps Script's `Code.gs`.
+
+Quick check: scroll to the bottom of `Code.gs` in Apps Script. Look for a function named `rebuildSprintTwoFormDynamic`.
+
+- If it's there, your Apps Script is current. Skip to step 4.3.
+- If it's NOT there, your Apps Script is stale. Copy the entire contents of `2026/polling/forms/create_form.gs` from your local repo and paste it into `Code.gs`, replacing everything. Save (Ctrl/Cmd + S).
+
+### 4.3 — Run the dynamic rebuild
+
+In Apps Script:
+
+1. In the toolbar, find the function-selector dropdown.
+2. Click it. Select `rebuildSprintTwoFormDynamic`.
+3. Click the Run button (▶).
+4. Watch the Execution log at the bottom.
+
+Expected output:
+
+```
+Fetched registry from remote:
+  Track B: 10 entries
+  Track A: 10 entries (or whatever the current count is)
+Existing items in form: ...
+Items wiped. Rebuilding...
+=== SPRINT 2 FORM REBUILT ===
+Items before:   ...
+Items after:    ...
+Form ID:        1lNZHaqUQC_A9DJeSy9JJ1FQkzE1T-lA92vbJLoE6K_k  (unchanged)
+Published URL:  https://docs.google.com/forms/d/e/.../viewform  (unchanged)
+==============================
+```
+
+**If you see "WARNING: form has responses already"** — stop. Real votes are in. Don't proceed without checking the response Sheet first.
+
+**If you see "ERROR: failed to fetch registry from GitHub"** — your Phase 3 push hasn't propagated to the raw URL yet. Wait 30 seconds, re-run.
+
+### 4.4 — Spot-check the form
+
+Click the eye/preview icon (top right of the Forms editor) to see the voter view.
+
+Page through. Confirm:
+
+- "About You" page is intact (affiliation, familiarity, GitHub handle, single-ballot pledge).
+- Track B entries are LLM01 through LLM10.
+- Specifically: any entries that were renamed (e.g., LLM07 if today) show the new title.
+- Track A section appears with the correct number of candidates.
+- New candidates are present.
+
+If anything looks wrong, stop. Don't post comms yet.
+
+**Checkpoint:** Form is live, URL unchanged, content reflects latest state.
+
+# Phase 5: Validate GitHub state
+
+Quick programmatic spot-check via Claude Code so you can confirm Phase 3 landed properly without clicking through the GitHub UI.
+
+**Claude Code prompt:**
+
+```
+Validate the OWASP Sprint 2 GitHub state after the sync.
+
+Steps:
+1. Count current Sprint 2 issues:
+   gh issue list --repo GenAI-Security-Project/GenAI-LLM-Top10 --label sprint-2 --state all --limit 100 --json number,title,labels | python3 -c "
+   import json, sys
+   issues = json.load(sys.stdin)
+   print(f'Total sprint-2 issues: {len(issues)}')
+   for i in issues:
+       labels = [l['name'] for l in i['labels']]
+       entry_id = next((l for l in labels if l.startswith('LLM') or l.startswith('TB-')), '?')
+       print(f'  #{i[\"number\"]:4d}  [{entry_id:8s}]  {i[\"title\"]}')
+   "
+
+2. Tell me:
+   - Total count (should equal 10 Track B + N Track A candidates)
+   - Any titles that look wrong or stale
+   - Specifically: confirm LLM07's title reflects the current entry name (not the old one if it was renamed)
+
+3. Print the live registry's entry counts from main:
+   curl -s https://raw.githubusercontent.com/GenAI-Security-Project/GenAI-LLM-Top10/main/2026/polling/scripts/issues.json | python3 -c "
+   import json, sys
+   d = json.load(sys.stdin)
+   print('Registry on main:')
+   print(f'  Track B: {len(d[\"track_b\"])}')
+   print(f'  Track A: {len(d[\"track_a\"])}')
+   "
+
+4. Confirm: total issues count == Track B count + Track A count from the registry. Tell me if there's a mismatch.
+
+5. Print 'PHASE 5 COMPLETE — GITHUB STATE VALIDATED' or describe any mismatches.
+```
+
+**Checkpoint:** Issue count matches registry count. Renamed entry titles look correct. No stale issues.
+
+# Phase 6: Validate (and maybe update) the pinned Discussion
+
+The pinned Discussion (https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/discussions/54) has hard-coded counts ("8 new candidate entries", "Sprint 3 cuts the 8 candidates to 5"). If the candidate count changed, update those.
+
+**Claude Code prompt:**
+
+```
+Check whether the pinned Sprint 2 Discussion (#54) needs updating to match the current Track A candidate count.
+
+Steps:
+1. Fetch the Discussion #54 body:
+   gh api graphql -f query='query {
+     repository(owner: "GenAI-Security-Project", name: "GenAI-LLM-Top10") {
+       discussion(number: 54) {
+         id
+         body
+       }
+     }
+   }' | python3 -c "
+   import json, sys
+   d = json.load(sys.stdin)
+   disc = d['data']['repository']['discussion']
+   print('DISCUSSION_ID:', disc['id'])
+   print('---BODY---')
+   print(disc['body'])
+   "
+
+2. Fetch the live Track A candidate count from main:
+   curl -s https://raw.githubusercontent.com/GenAI-Security-Project/GenAI-LLM-Top10/main/2026/polling/scripts/issues.json | python3 -c "
+   import json, sys
+   d = json.load(sys.stdin)
+   print(f'Live Track A count: {len(d[\"track_a\"])}')
+   "
+
+3. Compare:
+   - Does the Discussion body still say "8 new candidate entries"?
+   - Does it still say "Sprint 3 cuts the 8 candidates to 5"?
+   - Does the live Track A count match what the Discussion claims?
+
+4. If the count mismatches, propose the find-and-replace edits I need (e.g., "8 new candidate entries" -> "10 new candidate entries", "cuts the 8 candidates" -> "cuts the 10 candidates"). Do NOT apply them yet. Wait for my "go" before patching.
+
+5. If the count already matches, print 'DISCUSSION ALREADY MATCHES — NO UPDATE NEEDED' and stop.
+```
+
+**Checkpoint:** Either no update needed, or Claude Code has staged the find-and-replace.
+
+**If updates are needed**, paste this follow-up prompt:
+
+```
+Apply the Discussion update you proposed.
+
+Steps:
+1. Take the current Discussion body (from the previous step) and apply ONLY these find-and-replaces:
+   - "8 new candidate entries" -> "<new_count> new candidate entries"
+   - "Sprint 3 cuts the 8 candidates" -> "Sprint 3 cuts the <new_count> candidates"
+   (where <new_count> matches the live Track A count from issues.json)
+
+2. PATCH the Discussion via GraphQL using the discussion ID from the previous step.
+   Use a temp file for the body to avoid shell escaping issues.
+
+   gh api graphql -F discussionId="<DISCUSSION_ID>" -F "body=@/tmp/disc_body.md" -f query='mutation($discussionId:ID!, $body:String!) {
+     updateDiscussion(input: {discussionId: $discussionId, body: $body}) {
+       discussion { url number }
+     }
+   }'
+
+3. Confirm the response shows the Discussion was updated. Print the URL.
+
+4. Print 'PHASE 6 COMPLETE — DISCUSSION SYNCED'.
+```
+
+# Phase 7: Final spot-check (browser)
+
+Three quick visual checks before posting comms.
+
+**Browser, three tabs:**
+
+1. Open the Form's published URL: https://forms.gle/jFmqZF1R6k9gCEfi6
+   - Page through. Confirm Track B and Track A sections are correct.
+
+2. Open the issues filter: https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/issues?q=is%3Aissue+label%3Asprint-2
+   - Eyeball the count and titles. Click into any renamed issue (e.g., LLM07) to confirm the body links to the new file path.
+
+3. Open the pinned Discussion: https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/discussions/54
+   - Confirm candidate count is correct in the body text.
+
+If everything looks right, you're cleared to post comms.
+
+# Phase 8: Post the launch comms
+
+The drafts are in `2026/polling/comms/`. Order matters. About 5 minutes total.
+
+### 8.1 — Slack working group
+
+**Browser:** Open Slack, navigate to the OWASP Top 10 LLM working group channel.
+
+Open `2026/polling/comms/slack_workgroup.md` in your editor. Copy the body (everything after the `---` divider). Paste into the Slack channel. Send.
+
+### 8.2 — Steve's LinkedIn draft
+
+**Browser:** Email or DM Steve with the contents of `2026/polling/comms/linkedin_post_steve.md`.
+
+Tell him: "Draft for review. Post when ready, ideally 12-24 hours offset from mine for stagger." He'll rewrite to his voice.
+
+### 8.3 — Your LinkedIn
+
+**Browser:** Open LinkedIn, click "Start a post."
+
+Open `2026/polling/comms/linkedin_post_rock.md`. Copy the body (everything after the `---` divider, NOT including the Notes section at the bottom).
+
+Paste into LinkedIn. Add hashtags at the bottom of the post:
+
+```
+#OWASP #LLMSecurity #AISecurity #AIGovernance #AppSec
+```
+
+Tag Steve Wilson (`@Steve Wilson`) and any working group leads you want to amplify.
+
+Click Post.
+
+### 8.4 — Broader OWASP Slack
+
+**Browser:** Open Slack, navigate to broader OWASP project channels (`#project-llm-top10`, `#ai-security`, etc.).
+
+Open `2026/polling/comms/slack_broader.md`. Copy the body. Cross-post to each relevant channel.
+
+### 8.5 — Mailing list
+
+**Email:** Open `2026/polling/comms/mailing_list_launch.md`.
+
+Copy the subject line and body. Send to whoever owns the OWASP Top 10 LLM mailing list. Or, if you have access, send directly via the mailing list platform.
+
+# Phase 9: Final confirmation (Claude Code)
+
+Quick sanity check that everything is consistent post-launch.
+
+**Claude Code prompt:**
+
+```
+Final post-launch sanity check for OWASP Sprint 2.
+
+Steps:
+1. Print the live registry counts from main:
+   curl -s https://raw.githubusercontent.com/GenAI-Security-Project/GenAI-LLM-Top10/main/2026/polling/scripts/issues.json | python3 -c "
+   import json, sys
+   d = json.load(sys.stdin)
+   print(f'Track B: {len(d[\"track_b\"])}')
+   print(f'Track A: {len(d[\"track_a\"])}')
+   print(f'Form URL: {d[\"_meta\"][\"form\"][\"published_url\"]}')
+   print(f'Discussion: {d[\"_meta\"][\"discussion\"][\"url\"]}')
+   "
+
+2. Count live Sprint 2 issues:
+   gh issue list --repo GenAI-Security-Project/GenAI-LLM-Top10 --label sprint-2 --state all --limit 100 --json number | python3 -c "
+   import json, sys
+   issues = json.load(sys.stdin)
+   print(f'Live issues with sprint-2 label: {len(issues)}')
+   "
+
+3. Confirm:
+   - Track B + Track A from registry == live issue count
+   - Form URL is reachable (HEAD request)
+   - Discussion URL is reachable
+
+4. Print 'SPRINT 2 LAUNCH COMPLETE — VOTING IS LIVE'.
+```
+
+# If something goes wrong
+
+| Symptom | Where | Fix |
+| --- | --- | --- |
+| `gh auth status` says "not logged in" | Claude Code | Run `gh auth login`, pick web browser, HTTPS |
+| `git push` rejected (non-fast-forward) | Claude Code | `git pull --rebase`, resolve conflicts in `issues.json` (yours wins), `git push` |
+| Sync says "WARNING: no GH_TOKEN" | Claude Code | Re-run `export GH_TOKEN=$(gh auth token)` and retry |
+| Sync errors on remote read | Claude Code | GitHub API hiccup. Wait 30 sec, retry. |
+| Apps Script "ERROR: failed to fetch registry" | Browser | GitHub raw URL cache miss. Wait 30 sec, re-run `rebuildSprintTwoFormDynamic`. |
+| Apps Script "WARNING: form has responses already" | Browser | Real votes are in. Stop. Don't rebuild. Talk to me. |
+| Form section shows wrong title | Browser | Sync didn't write registry correctly. Re-run Phase 2 to inspect. |
+| LLM07 issue still has old title | Anywhere | PATCH didn't apply. Manually edit via GitHub UI, or paste the sync output to me. |
+| Discussion update fails | Claude Code | GraphQL permission issue. Update via GitHub UI: open #54, click pencil, find-and-replace. |
+
+For anything else, paste the output to me.
+
+# After tomorrow
+
+Sprint 2 voting runs through May 18, 23:59 UTC. Comment triage is daily. Mid-sprint turnout push is May 11. Aggregation pipeline build starts week 2. Separate runbooks will exist for each.

--- a/2026/polling/forms/blueprint.md
+++ b/2026/polling/forms/blueprint.md
@@ -10,6 +10,7 @@ This document specifies the single Google Form used for Sprint 2 voting. The App
 
 - **Published URL** (canonical, for GitHub issues and durable references): https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform
 - **Short URL** (for human-shared comms — LinkedIn, Slack, mailing list): https://forms.gle/jFmqZF1R6k9gCEfi6
+- **Edit URL** (working group only): https://docs.google.com/forms/d/1lNZHaqUQC_A9DJeSy9JJ1FQkzE1T-lA92vbJLoE6K_k/edit
 - **Form ID**: `1lNZHaqUQC_A9DJeSy9JJ1FQkzE1T-lA92vbJLoE6K_k`
 - **Generated**: May 4, 2026 from `create_form.gs`
 - **Owner account**: Rock Lambros' Google account
@@ -17,9 +18,9 @@ This document specifies the single Google Form used for Sprint 2 voting. The App
 
 ## Single ballot, both tracks
 
-One form covers Track A (10 existing entries) and Track B (8 new candidates). Voters land on a single URL, fill what they know, skip what they don't. The "captive audience" design boosts Track B participation by routing voters there after they finish the more familiar Track A entries.
+One form covers Track B (10 existing entries) and Track A (8 new candidates). Voters land on a single URL, fill what they know, skip what they don't. The "captive audience" design boosts Track A participation by routing voters there after they finish the more familiar Track B entries.
 
-Tracks remain analytically separate. Question titles tag every score with its entry ID (`LLM01 — Importance`, `TB-MCPX — Distinctness`), so the aggregation pipeline splits the data cleanly. Sprint plan still evaluates the tracks independently.
+Tracks remain analytically separate. Question titles tag every score with its entry ID (`LLM01 — Importance`, `TA-MCPX — Distinctness`), so the aggregation pipeline splits the data cleanly. Sprint plan still evaluates the tracks independently.
 
 ## Voting close
 
@@ -41,7 +42,7 @@ Form closes May 18, 2026 at 23:59 UTC. The aggregation pipeline runs on May 19.
 | Page | Content | Required fields |
 | --- | --- | --- |
 | 1 | About You — voter metadata | Affiliation, familiarity, single-ballot pledge |
-| 2 | Track A intro + LLM01 (Prompt Injection) scoring | None (all Likerts optional) |
+| 2 | Track B intro + LLM01 (Prompt Injection) scoring | None (all Likerts optional) |
 | 3 | LLM02 Sensitive Information Disclosure | None |
 | 4 | LLM03 Supply Chain | None |
 | 5 | LLM04 Data and Model Poisoning | None |
@@ -51,14 +52,14 @@ Form closes May 18, 2026 at 23:59 UTC. The aggregation pipeline runs on May 19.
 | 9 | LLM08 Vector and Embedding Weaknesses | None |
 | 10 | LLM09 Misinformation | None |
 | 11 | LLM10 Unbounded Consumption | None |
-| 12 | Track B intro + TB-CFAS (Compositional Fine-Tuning Alignment Subversion) | None |
-| 13 | TB-CMSB Cross-Modal Safety Bypass | None |
-| 14 | TB-ITSC Inference-Time Side-Channel Disclosure | None |
-| 15 | TB-MCPX MCP Tool Interface Exploitation | None |
-| 16 | TB-MMIS Model Misalignment | None |
-| 17 | TB-MSDA Model Scheming and Deceptive Alignment | None |
-| 18 | TB-SICG Systemic Insecure Code Generation | None |
-| 19 | TB-WLLA Weaponized LLM Abuse | None |
+| 12 | Track A intro + TA-CFAS (Compositional Fine-Tuning Alignment Subversion) | None |
+| 13 | TA-CMSB Cross-Modal Safety Bypass | None |
+| 14 | TA-ITSC Inference-Time Side-Channel Disclosure | None |
+| 15 | TA-MCPX MCP Tool Interface Exploitation | None |
+| 16 | TA-MMIS Model Misalignment | None |
+| 17 | TA-MSDA Model Scheming and Deceptive Alignment | None |
+| 18 | TA-SICG Systemic Insecure Code Generation | None |
+| 19 | TA-WLLA Weaponized LLM Abuse | None |
 
 Total: 19 pages. Estimated completion time 10 minutes if voter scores everything, 1–2 minutes if voter scores one entry.
 
@@ -82,7 +83,7 @@ Each entry is on its own page. The section header at the top of every entry page
 - Direct link to the draft markdown on GitHub
 - Direct link to the entry's GitHub feedback issue (filtered by label)
 
-### Track A: 2 Likert questions per entry
+### Track B: 2 Likert questions per entry
 
 | Question | Scale | Required |
 | --- | --- | --- |
@@ -90,7 +91,7 @@ Each entry is on its own page. The section header at the top of every entry page
 | Clarity | 1–5 (1 Confusing, 5 Crystal clear) | No |
 | Brief comment | Paragraph text | No |
 
-### Track B: 3 Likert questions per entry
+### Track A: 3 Likert questions per entry
 
 | Question | Scale | Required |
 | --- | --- | --- |
@@ -99,13 +100,13 @@ Each entry is on its own page. The section header at the top of every entry page
 | Distinctness | 1–5 (1 Already covered, 5 Clearly distinct) | No |
 | Brief comment | Paragraph text | No |
 
-Distinctness is Track B only. It tells Sprint 3 whether a high-Importance candidate is a standalone entry or a merge into an existing one. Cuts the risk of Sprint 4 churn over duplicative entries.
+Distinctness is Track A only. It tells Sprint 3 whether a high-Importance candidate is a standalone entry or a merge into an existing one. Cuts the risk of Sprint 4 churn over duplicative entries.
 
 ### Why all Likerts are optional
 
 Skipping is a deliberate signal. Voters who do not feel qualified to score an entry should leave it blank. Skip rate per entry feeds the analysis. Forcing a vote produces noise.
 
-## Track A entries (10)
+## Track B entries (10)
 
 | ID | Title | Draft file |
 | --- | --- | --- |
@@ -120,28 +121,28 @@ Skipping is a deliberate signal. Voters who do not feel qualified to score an en
 | LLM09 | Misinformation | LLM09_Misinformation.md |
 | LLM10 | Unbounded Consumption | LLM10_UnboundedConsumption.md |
 
-## Track B candidates (8)
+## Track A candidates (8)
 
 | ID | Title | Draft file |
 | --- | --- | --- |
-| TB-CFAS | Compositional Fine-Tuning Alignment Subversion | compositional-finetuning-alignment-subversion.md |
-| TB-CMSB | Cross-Modal Safety Bypass | cross-modal-safety-bypass.md |
-| TB-ITSC | Inference-Time Side-Channel Disclosure | inference-time-side-channel-disclosure.md |
-| TB-MCPX | MCP Tool Interface Exploitation | mcp-tool-interface-exploitation.md |
-| TB-MMIS | Model Misalignment | model-misalignment.md |
-| TB-MSDA | Model Scheming and Deceptive Alignment | model-scheming-and-deceptive-alignment.md |
-| TB-SICG | Systemic Insecure Code Generation | systemic-insecure-code-generation.md |
-| TB-WLLA | Weaponized LLM Abuse | weaponized-llm-abuse.md |
+| TA-CFAS | Compositional Fine-Tuning Alignment Subversion | compositional-finetuning-alignment-subversion.md |
+| TA-CMSB | Cross-Modal Safety Bypass | cross-modal-safety-bypass.md |
+| TA-ITSC | Inference-Time Side-Channel Disclosure | inference-time-side-channel-disclosure.md |
+| TA-MCPX | MCP Tool Interface Exploitation | mcp-tool-interface-exploitation.md |
+| TA-MMIS | Model Misalignment | model-misalignment.md |
+| TA-MSDA | Model Scheming and Deceptive Alignment | model-scheming-and-deceptive-alignment.md |
+| TA-SICG | Systemic Insecure Code Generation | systemic-insecure-code-generation.md |
+| TA-WLLA | Weaponized LLM Abuse | weaponized-llm-abuse.md |
 
-The TB-XXXX IDs are GitHub label values. They keep issue filter URLs short and stable even if the candidate title changes.
+The TA-XXXX IDs are GitHub label values. They keep issue filter URLs short and stable even if the candidate title changes.
 
 ## Known limitations
 
 **Section deep-linking**: Google Forms always opens at page 1. Issues for specific entries link to the same Form URL. The issue body explains how to navigate. Voters who land on the form from an LLM05 issue still see "About You" first and have to page through to LLM05. Acceptable cost for the captive-audience benefit.
 
-**Order bias**: Track A always comes before Track B. Track A always lists LLM01 → LLM10 in canonical order. Voters who fatigue mid-form score later entries less generously. Aggregation reports completion rate per entry to flag this.
+**Order bias**: Track B always comes before Track A. Track B always lists LLM01 → LLM10 in canonical order. Voters who fatigue mid-form score later entries less generously. Aggregation reports completion rate per entry to flag this.
 
-**Drop-off mid-form**: 19 pages. Some voters will abandon partway through. The aggregation pipeline tracks "completed Track A only" vs "completed both" as a participation segmentation, and reports per-entry response rate as a completion proxy.
+**Drop-off mid-form**: 19 pages. Some voters will abandon partway through. The aggregation pipeline tracks "completed Track B only" vs "completed both" as a participation segmentation, and reports per-entry response rate as a completion proxy.
 
 **Workspace gating**: `setLimitOneResponsePerUser` only enforces inside Google Workspace. Public OWASP voting will not have it. Email dedup in aggregation compensates.
 

--- a/2026/polling/forms/create_form.gs
+++ b/2026/polling/forms/create_form.gs
@@ -7,8 +7,8 @@
  *
  * WHAT THIS DOES
  *   Programmatically creates the Sprint 2 Google Form covering both tracks:
- *     - Track A: 10 existing entries (Importance + Clarity)
- *     - Track B:  8 new candidates  (Importance + Clarity + Distinctness)
+ *     - Track B: 10 existing entries (Importance + Clarity)
+ *     - Track A:  8 new candidates  (Importance + Clarity + Distinctness)
  *
  *   One ballot, one URL, one captive audience. All Likerts are optional.
  *   Voters skip any entry they have not read. Skip rate is a deliberate metric.
@@ -27,12 +27,17 @@
  *   - setLimitOneResponsePerUser is a Google Workspace feature. If the project
  *     is not on a Workspace account, the call is a no-op and dedup falls to
  *     the aggregation pipeline (which dedups by collected email).
- *   - Track A appears first because the existing entries are familiar; that
- *     builds voter momentum into the Track B section.
+ *   - Track B appears first because the existing entries are familiar; that
+ *     builds voter momentum into the Track A section.
  *   - Each entry is on its own page so voters see progress and can resume.
  */
 
 // ---------- Configuration ----------
+
+// Form ID of the existing live form. Used by rebuildSprintTwoForm() to
+// update in place without changing the URL. Source of truth: same value
+// stored in scripts/issues.json under _meta.form.form_id.
+const FORM_ID = '1lNZHaqUQC_A9DJeSy9JJ1FQkzE1T-lA92vbJLoE6K_k';
 
 const FORM_TITLE =
   'OWASP Top 10 for LLM Applications 2026 — Sprint 2 Community Vote';
@@ -44,14 +49,14 @@ const REPO_CANDIDATE_BASE =
   'https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/blob/main/2026/new_entry_candidates/';
 
 const REPO_ISSUE_BASE_A =
-  'https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/issues?q=is%3Aissue+label%3Atrack-a+label%3A';
+  'https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/issues?q=is%3Aissue+label%3Atrack-b+label%3A';
 
 const REPO_ISSUE_BASE_B =
-  'https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/issues?q=is%3Aissue+label%3Atrack-b+label%3A';
+  'https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/issues?q=is%3Aissue+label%3Atrack-a+label%3A';
 
 const VOTING_CLOSE = 'May 18, 2026 at 23:59 UTC';
 
-const TRACK_A_ENTRIES = [
+const TRACK_B_ENTRIES = [
   { id: 'LLM01', title: 'Prompt Injection',                       file: 'LLM01_PromptInjection.md' },
   { id: 'LLM02', title: 'Sensitive Information Disclosure',       file: 'LLM02_SensitiveInformationDisclosure.md' },
   { id: 'LLM03', title: 'Supply Chain',                           file: 'LLM03_SupplyChain.md' },
@@ -64,15 +69,15 @@ const TRACK_A_ENTRIES = [
   { id: 'LLM10', title: 'Unbounded Consumption',                  file: 'LLM10_UnboundedConsumption.md' },
 ];
 
-const TRACK_B_ENTRIES = [
-  { id: 'TB-CFAS', title: 'Compositional Fine-Tuning Alignment Subversion', file: 'compositional-finetuning-alignment-subversion.md' },
-  { id: 'TB-CMSB', title: 'Cross-Modal Safety Bypass',                       file: 'cross-modal-safety-bypass.md' },
-  { id: 'TB-ITSC', title: 'Inference-Time Side-Channel Disclosure',          file: 'inference-time-side-channel-disclosure.md' },
-  { id: 'TB-MCPX', title: 'MCP Tool Interface Exploitation',                 file: 'mcp-tool-interface-exploitation.md' },
-  { id: 'TB-MMIS', title: 'Model Misalignment',                              file: 'model-misalignment.md' },
-  { id: 'TB-MSDA', title: 'Model Scheming and Deceptive Alignment',          file: 'model-scheming-and-deceptive-alignment.md' },
-  { id: 'TB-SICG', title: 'Systemic Insecure Code Generation',               file: 'systemic-insecure-code-generation.md' },
-  { id: 'TB-WLLA', title: 'Weaponized LLM Abuse',                            file: 'weaponized-llm-abuse.md' },
+const TRACK_A_ENTRIES = [
+  { id: 'TA-CFAS', title: 'Compositional Fine-Tuning Alignment Subversion', file: 'compositional-finetuning-alignment-subversion.md' },
+  { id: 'TA-CMSB', title: 'Cross-Modal Safety Bypass',                       file: 'cross-modal-safety-bypass.md' },
+  { id: 'TA-ITSC', title: 'Inference-Time Side-Channel Disclosure',          file: 'inference-time-side-channel-disclosure.md' },
+  { id: 'TA-MCPX', title: 'MCP Tool Interface Exploitation',                 file: 'mcp-tool-interface-exploitation.md' },
+  { id: 'TA-MMIS', title: 'Model Misalignment',                              file: 'model-misalignment.md' },
+  { id: 'TA-MSDA', title: 'Model Scheming and Deceptive Alignment',          file: 'model-scheming-and-deceptive-alignment.md' },
+  { id: 'TA-SICG', title: 'Systemic Insecure Code Generation',               file: 'systemic-insecure-code-generation.md' },
+  { id: 'TA-WLLA', title: 'Weaponized LLM Abuse',                            file: 'weaponized-llm-abuse.md' },
 ];
 
 // ---------- Entry point ----------
@@ -114,13 +119,141 @@ function createSprintTwoForm() {
   Logger.log('Next step: paste the Published URL into ../scripts/create_issues.py --form-url');
 }
 
+// ---------- Update path: rebuild existing form on the same URL ----------
+
+/**
+ * Rebuilds the live Sprint 2 form on the existing Form ID. URL stays the
+ * same. All items get wiped and re-added from the TRACK_B_ENTRIES and
+ * TRACK_A_ENTRIES arrays above. Use this when:
+ *
+ *   - You have edits to existing entry titles, files, or rubric text
+ *   - You're adding new candidate entries to Track A
+ *   - Voting hasn't accumulated meaningful responses yet
+ *
+ * DO NOT run this once real votes are in. Wiping items breaks the response
+ * Sheet schema. Old responses sit in orphaned columns; new responses get
+ * fresh columns. Aggregation becomes a manual reconciliation job.
+ *
+ * SAFE OPERATING WINDOW: first 24-48 hours of voting, before the comms
+ * launch hits the broader audience, while turnout is single-digit.
+ *
+ * Workflow:
+ *   1. Edit TRACK_B_ENTRIES and/or TRACK_A_ENTRIES arrays above to reflect
+ *      the new state (rename entries, add new candidates, update file refs).
+ *   2. Save the script.
+ *   3. Run rebuildSprintTwoForm(). URL stays the same. Issues already on
+ *      GitHub continue to point at the right form.
+ *   4. For NEW candidates added: run create_issues.py with --only-ids to
+ *      create just the new GitHub issues without duplicating the existing 18.
+ */
+function rebuildSprintTwoForm() {
+  const form = FormApp.openById(FORM_ID);
+
+  const beforeCount = form.getItems().length;
+  Logger.log('Existing items in form: ' + beforeCount);
+  Logger.log('Existing response count: ' + form.getResponses().length);
+
+  // Defensive: log a warning if there are responses already.
+  if (form.getResponses().length > 0) {
+    Logger.log('WARNING: form has responses already. Rebuild will orphan ' +
+               'response columns. Export the response Sheet first.');
+  }
+
+  // Wipe items. Repeatedly delete index 0 to avoid index-shift bugs.
+  while (form.getItems().length > 0) {
+    form.deleteItem(form.getItems()[0]);
+  }
+  Logger.log('Items wiped. Rebuilding...');
+
+  // Re-apply title and description in case they changed in the script.
+  form.setTitle(FORM_TITLE);
+  form.setDescription(buildDescription());
+
+  // Rebuild from the (potentially edited) entry arrays.
+  buildVoterMetadataPage(form);
+  buildTrackAEntries(form);
+  buildTrackBEntries(form);
+
+  const afterCount = form.getItems().length;
+  Logger.log('=== SPRINT 2 FORM REBUILT ===');
+  Logger.log('Items before:   ' + beforeCount);
+  Logger.log('Items after:    ' + afterCount);
+  Logger.log('Form ID:        ' + form.getId() + '  (unchanged)');
+  Logger.log('Published URL:  ' + form.getPublishedUrl() + '  (unchanged)');
+  Logger.log('Track B count:  ' + TRACK_B_ENTRIES.length);
+  Logger.log('Track A count:  ' + TRACK_A_ENTRIES.length);
+  Logger.log('==============================');
+  Logger.log('If you added new Track A candidates, fire their GitHub issues:');
+  Logger.log('  cd polling/scripts');
+  Logger.log('  export GH_TOKEN=$(gh auth token)');
+  Logger.log('  python3 create_issues.py --form-url <URL> --only-ids "TA-XXXX,TA-YYYY"');
+}
+
+// ---------- Dynamic update path: pulls entry list from remote issues.json ----------
+
+/**
+ * Rebuild the form using the entry list from the LIVE issues.json on GitHub.
+ *
+ * This is the recommended update path when the team is making changes via
+ * sync_sprint2.py (which writes to local issues.json that then gets pushed
+ * to main). Apps Script fetches the latest registry from raw.githubusercontent
+ * and rebuilds the form against that. No need to copy/paste entry arrays.
+ *
+ * WORKFLOW
+ *   1. On your machine: python3 sync_sprint2.py
+ *   2. git push the updated issues.json
+ *   3. In Apps Script: run rebuildSprintTwoFormDynamic()
+ *
+ * The Apps Script reads the public raw URL of issues.json. No auth needed.
+ * Cache: GitHub raw URLs serve the latest commit on the named branch
+ * within seconds.
+ */
+const REGISTRY_URL =
+  'https://raw.githubusercontent.com/GenAI-Security-Project/GenAI-LLM-Top10/main/2026/polling/scripts/issues.json';
+
+function rebuildSprintTwoFormDynamic() {
+  // Fetch the registry from the remote repo
+  let registry;
+  try {
+    const response = UrlFetchApp.fetch(REGISTRY_URL, {
+      muteHttpExceptions: false,
+      followRedirects: true,
+      validateHttpsCertificates: true,
+    });
+    registry = JSON.parse(response.getContentText());
+  } catch (e) {
+    Logger.log('ERROR: failed to fetch registry from GitHub: ' + e);
+    Logger.log('URL: ' + REGISTRY_URL);
+    Logger.log('Falling back to in-script TRACK_B_ENTRIES and TRACK_A_ENTRIES.');
+    Logger.log('To use the dynamic path, run sync_sprint2.py and push issues.json first.');
+    rebuildSprintTwoForm();
+    return;
+  }
+
+  const remoteA = registry.track_b || [];
+  const remoteB = registry.track_a || [];
+  Logger.log('Fetched registry from remote:');
+  Logger.log('  Track B: ' + remoteA.length + ' entries');
+  Logger.log('  Track A: ' + remoteB.length + ' entries');
+
+  // Override the in-script arrays with the remote ones, in place. Note that
+  // const-bound arrays can't be reassigned, but we can mutate them.
+  TRACK_B_ENTRIES.length = 0;
+  remoteA.forEach(function (e) { TRACK_B_ENTRIES.push(e); });
+  TRACK_A_ENTRIES.length = 0;
+  remoteB.forEach(function (e) { TRACK_A_ENTRIES.push(e); });
+
+  // Hand off to the existing rebuild function
+  rebuildSprintTwoForm();
+}
+
 // ---------- Description ----------
 
 function buildDescription() {
   return [
     'Single ballot covering both tracks of the Sprint 2 community vote:',
-    '  Track A — 10 refreshed existing entries (LLM01–LLM10)',
-    '  Track B — 8 new candidate entries',
+    '  Track B — 10 refreshed existing entries (LLM01–LLM10)',
+    '  Track A — 8 new candidate entries',
     '',
     'Estimated time: 10 minutes if you score every entry. Less if you skip ' +
     'entries you have not read. Skipping is a valid signal — it tells the ' +
@@ -128,14 +261,14 @@ function buildDescription() {
     '',
     'WHAT TO DO',
     '1. Read each entry on GitHub (links provided per section).',
-    '2. Score Importance and Clarity on a 1–5 scale. Track B adds Distinctness.',
+    '2. Score Importance and Clarity on a 1–5 scale. Track A adds Distinctness.',
     '3. Use the GitHub issue link under each entry for qualitative comments. ' +
     'The form captures scores. The issues capture discussion.',
     '',
     'DEFINITIONS',
     '• Importance: How critical is this risk to LLM application security in 2026?',
     '• Clarity: How clearly does the entry describe the risk and mitigations?',
-    '• Distinctness (Track B only): Is this materially different from existing ' +
+    '• Distinctness (Track A only): Is this materially different from existing ' +
     'entries (LLM01–LLM10), or could it be merged into one of them?',
     '',
     'INTEGRITY',
@@ -195,37 +328,37 @@ function buildVoterMetadataPage(form) {
       .setRequired(true);
 }
 
-// ---------- Track A ----------
+// ---------- Track B ----------
 
 function buildTrackAEntries(form) {
   form.addPageBreakItem()
-      .setTitle('Track A: Existing Entries (LLM01–LLM10)')
+      .setTitle('Track B: Existing Entries (LLM01–LLM10)')
       .setHelpText('Score Importance and Clarity for each existing entry. ' +
                    'Leave blank any entry you have not read. Estimated time: ' +
-                   '5 minutes. Track B (new candidates) follows after this section.');
+                   '5 minutes. Track A (new candidates) follows after this section.');
 
-  TRACK_A_ENTRIES.forEach(function (entry, idx) {
-    addEntrySection(form, entry, false /* not Track B */, REPO_ENTRY_BASE, REPO_ISSUE_BASE_A);
-    if (idx !== TRACK_A_ENTRIES.length - 1) {
+  TRACK_B_ENTRIES.forEach(function (entry, idx) {
+    addEntrySection(form, entry, false /* not Track A */, REPO_ENTRY_BASE, REPO_ISSUE_BASE_A);
+    if (idx !== TRACK_B_ENTRIES.length - 1) {
       form.addPageBreakItem();
     }
   });
 }
 
-// ---------- Track B ----------
+// ---------- Track A ----------
 
 function buildTrackBEntries(form) {
   form.addPageBreakItem()
-      .setTitle('Track B: New Candidate Entries')
+      .setTitle('Track A: New Candidate Entries')
       .setHelpText('Now scoring new candidates for the 2026 Top 10. Sprint 3 ' +
-                   'cuts these 8 down to 5. Track B adds a third dimension — ' +
+                   'cuts these 8 down to 5. Track A adds a third dimension — ' +
                    'Distinctness — which tells us whether a candidate stands ' +
                    'alone or should merge into an existing entry. Estimated ' +
                    'time: 5 minutes. Skip any candidate you have not read.');
 
-  TRACK_B_ENTRIES.forEach(function (entry, idx) {
-    addEntrySection(form, entry, true /* Track B */, REPO_CANDIDATE_BASE, REPO_ISSUE_BASE_B);
-    if (idx !== TRACK_B_ENTRIES.length - 1) {
+  TRACK_A_ENTRIES.forEach(function (entry, idx) {
+    addEntrySection(form, entry, true /* Track A */, REPO_CANDIDATE_BASE, REPO_ISSUE_BASE_B);
+    if (idx !== TRACK_A_ENTRIES.length - 1) {
       form.addPageBreakItem();
     }
   });

--- a/2026/polling/forms/update_guide.md
+++ b/2026/polling/forms/update_guide.md
@@ -1,0 +1,117 @@
+# Mid-Sprint Form Update Guide
+
+Owner: Rock Lambros
+Use case: Edits to existing entries, new candidate entries, or both, while keeping the live Form URL stable.
+
+## Recommended workflow: dynamic sync
+
+The team pushes entry changes (text edits, file renames, new candidates) directly to `main`. Run one Python command and one Apps Script function. No manual array editing. No manual issue firing.
+
+```bash
+cd /Users/klambros/github_projects/GenAI-LLM-Top10
+git pull                                 # not strictly required (script reads remote)
+export GH_TOKEN=$(gh auth token)
+
+# Preview what would change
+python3 2026/polling/scripts/sync_sprint2.py --dry-run
+
+# Apply: updates issues.json, fires only missing GitHub issues
+python3 2026/polling/scripts/sync_sprint2.py
+
+# Push the updated registry so Apps Script can fetch it
+git add 2026/polling/scripts/issues.json
+git commit -m "Sprint 2: sync entry registry"
+git push
+```
+
+Then in Apps Script:
+
+1. Open the existing project (the one tied to the live Form).
+2. Run `rebuildSprintTwoFormDynamic()`. It fetches the updated `issues.json` from raw.githubusercontent.com and rebuilds the form against it.
+3. Form URL stays the same. Voters keep using the same link.
+
+That's it. Two commands, one click in Apps Script.
+
+## What the sync script does
+
+Reads from the **remote repo on `main`** (not your local clone, which may be stale):
+
+1. Lists `2026/` and detects existing entries (LLM01 through LLM10). Excludes `LLM00_Preface.md`.
+2. Lists `2026/new_entry_candidates/` and detects Track A candidates.
+3. Pulls each markdown file's first heading and parses out the human title.
+4. For new candidates, auto-generates a stable `TA-XXXX` ID from the filename slug (first letter of up to 4 words). For renamed candidates, reuses the existing ID from the registry.
+5. Diffs against the local `issues.json` registry. Reports what's new, changed (file rename or title edit), or removed.
+6. Updates `issues.json` with the reconciled state. Adds labels for any new candidate IDs.
+7. Fetches existing GitHub issues with `label:sprint-2`. For any entry without an issue, fires a new one (using the existing issue body templates).
+
+Source of truth: the remote repo. Local `issues.json` is a derived registry that gets committed for traceability and to feed Apps Script.
+
+## Flags
+
+| Flag | Effect |
+| --- | --- |
+| `--dry-run` | Show diff and proposed actions without writing or firing |
+| `--no-fire` | Update `issues.json` but skip creating new GitHub issues |
+| `--no-write` | Read-only — don't update `issues.json`. Useful with `--no-fire` to inspect remote |
+| `--branch BRANCH` | Read from a branch other than `main` |
+| `--form-url URL` | Override the form URL for new issues (defaults to `_meta.form.published_url` in `issues.json`) |
+
+## Removals: handled with care
+
+If a file disappears from the remote (e.g., a candidate dropped from consideration), the sync script:
+
+- Reports it under `[-] REMOVED` with a warning.
+- Does NOT auto-delete the entry from `issues.json`.
+- Does NOT close the corresponding GitHub issue.
+
+This is intentional. Auto-removing entries mid-sprint loses the votes already collected for them. If you genuinely want to drop an entry:
+
+1. Manually edit `issues.json` to remove the entry from `track_b` or `track_a`.
+2. Comment on the corresponding GitHub issue explaining the working group decision and close it.
+3. Re-run `sync_sprint2.py` to verify clean state.
+
+## When NOT to run sync
+
+| Voting state | Safe to sync? |
+| --- | --- |
+| Just launched, single-digit responses | Yes |
+| Active turnout, 10 to 25 responses | Mostly safe. Form rebuild changes question IDs, but new responses still flow into the Sheet's right-hand columns. Aggregation handles the merge. |
+| 25+ responses | Run only if the team genuinely needs the change. Coordinate with the working group. |
+
+The form rebuild changes question IDs every time. Old responses keep their old column data; new responses get fresh columns. Aggregation reconciles by entry ID, so this is workable. But every rebuild adds reconciliation overhead.
+
+## Manual fallback paths
+
+If the sync script breaks for any reason, you have two manual paths:
+
+### Surgical path (most conservative)
+
+Open the form via the Edit URL. Click into individual sections to update titles or links. Append new sections at the end of Track A. No script needed. Slow but lossless.
+
+### Static rebuild path
+
+Edit `TRACK_B_ENTRIES` and `TRACK_A_ENTRIES` in `create_form.gs` by hand. Paste the script into Apps Script. Run `rebuildSprintTwoForm()` (the static version). Then manually update `issues.json` and run `create_issues.py --only-ids "TA-NEWX"` for new candidates.
+
+This is the path the static `rebuildSprintTwoForm()` and `create_issues.py --only-ids` were originally built for. They still work. The sync script is just a higher-level wrapper.
+
+## Verification after sync
+
+After running sync and the Apps Script rebuild, sanity-check:
+
+1. Open the form's published URL. Page through. Confirm the new candidates appear and the renames look right.
+2. Check the GitHub issue list filtered by `label:sprint-2`. Count should match the entry count in the new `issues.json`.
+3. Check the Discussion. Pinned content shouldn't need updating unless category descriptions changed.
+
+If anything looks off, re-run `sync_sprint2.py --dry-run` to see what the script thinks the current state is. The diff is your debugger.
+
+## What the rebuild changes vs preserves
+
+| Asset | Preserved | Notes |
+| --- | --- | --- |
+| Form URL (Published, Short, Edit) | Yes | Same Form ID, same URLs |
+| Form title and description | Refreshed from script | If you changed `FORM_TITLE` or `buildDescription()`, those update |
+| Voter metadata page (About You) | Wiped and rebuilt | Question IDs change; affects column mapping |
+| Per-entry sections | Wiped and rebuilt | Same |
+| Submitted responses | Stay in Sheet | Old responses sit in old columns; new ones go to fresh columns |
+| Linked response Sheet | Stays linked | Aggregation pipeline handles column reconciliation by entry ID |
+| Form ID | Unchanged | Aggregation pipeline still finds the Sheet via Form ID |

--- a/2026/polling/scripts/create_issues.py
+++ b/2026/polling/scripts/create_issues.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 OWASP Top 10 for LLM Applications — 2026 Update
-Sprint 2: Bulk-create the 18 feedback issues (10 Track A + 8 Track B).
+Sprint 2: Bulk-create the 18 feedback issues (10 Track B + 8 Track A).
 
 Owner:    Rock Lambros (rock@rockcyber.ai)
 Version:  1.0
@@ -11,21 +11,32 @@ WHAT THIS DOES
   1. Ensures the 22 Sprint 2 labels exist in the repo (idempotent — creates
      missing, leaves existing alone, updates color/description on existing).
   2. Creates one feedback issue per existing entry (10) and per candidate (8).
-  3. Substitutes the Track A and Track B Form URLs into each issue body.
+  3. Substitutes the Track B and Track A Form URLs into each issue body.
 
 USAGE
-  export GH_TOKEN="ghp_..."          # PAT with `repo` scope
+  # Initial fire (creates all 18 issues + 22 labels)
+  export GH_TOKEN="ghp_..."          # PAT with `repo` scope, or use $(gh auth token)
   python create_issues.py \\
       --form-url "https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform" \\
       --dry-run                      # render without posting
+
+  # Mid-sprint update: fire issues for ONLY new entries you added
+  python create_issues.py \\
+      --form-url "https://..." \\
+      --only-ids "TA-NEW1,TA-NEW2"   # comma-separated entry IDs from issues.json
 
   Run without --dry-run to fire for real. Issues post sequentially with a
   short pause to stay under GitHub's secondary rate limits.
 
   --form-url is a single Google Form URL covering both tracks. Sprint 2
   consolidated to one ballot so voters land on a single URL and roll from
-  Track A into Track B in one captive session. The live URL is also
+  Track B into Track A in one captive session. The live URL is also
   recorded in issues.json under _meta.form.published_url.
+
+  --only-ids filters issues.json by entry ID (LLM01, TA-CFAS, etc.). Use
+  when adding new candidates mid-sprint to avoid duplicating the existing
+  issues. Labels still upsert idempotently. Without --only-ids the script
+  fires all entries from issues.json.
 
 EXIT CODES
   0  success
@@ -111,7 +122,7 @@ def ensure_labels(labels: list[dict], token: str, dry_run: bool) -> None:
 
 # ---------- Issue bodies ----------
 
-TRACK_A_BODY = """## Sprint 2 Feedback — {entry_id} {entry_title}
+TRACK_B_BODY = """## Sprint 2 Feedback — {entry_id} {entry_title}
 
 This issue collects **qualitative feedback** on the refreshed **{entry_id} {entry_title}** entry. \
 Submit your **Importance** and **Clarity** scores via the Sprint 2 Google Form (single ballot covering both tracks).
@@ -140,7 +151,7 @@ Evidence: <CVE, paper, incident, or research note ID if applicable>
 ### Out of scope here
 
 - Cross-cutting comments → use [Discussions]({discussions_url})
-- Questions about Track B candidates → comment on the relevant Track B issue
+- Questions about Track A candidates → comment on the relevant Track A issue
 - Process or governance questions → comment in [Discussions]({discussions_url})
 
 ### Triage
@@ -153,12 +164,12 @@ Working group entry leads classify each comment within 48 hours as:
 Sprint 3 begins May 18 with this issue's triage as input.
 """
 
-TRACK_B_BODY = """## Sprint 2 Feedback — {entry_title}
+TRACK_A_BODY = """## Sprint 2 Feedback — {entry_title}
 
 This issue collects **qualitative feedback** on the **{entry_title}** new candidate entry. \
 Submit your **Importance**, **Clarity**, and **Distinctness** scores via the Sprint 2 Google Form (single ballot covering both tracks).
 
-- **Vote**: {form_url} — page through to the Track B section, then to **{entry_title}**
+- **Vote**: {form_url} — page through to the Track A section, then to **{entry_title}**
 - **Read the draft**: https://github.com/{repo}/blob/main/2026/new_entry_candidates/{file}
 - **Voting closes**: May 18, 2026 at 23:59 UTC
 - **Code of Conduct**: https://owasp.org/www-policy/operational/code-of-conduct
@@ -188,7 +199,7 @@ Evidence: <CVE, paper, incident, or research note ID if applicable>
 ### Out of scope here
 
 - Cross-cutting comments → use [Discussions]({discussions_url})
-- Comments on existing entries (LLM01–LLM10) → comment on the relevant Track A issue
+- Comments on existing entries (LLM01–LLM10) → comment on the relevant Track B issue
 - Process or governance questions → comment in [Discussions]({discussions_url})
 
 ### Triage
@@ -205,9 +216,9 @@ DISCUSSIONS_URL = f"https://github.com/{REPO}/discussions"
 
 # ---------- Issue creation ----------
 
-def render_track_a(entry: dict, form_url: str) -> tuple[str, str]:
-    title = f"[Track A] Feedback: {entry['id']} — {entry['title']}"
-    body = TRACK_A_BODY.format(
+def render_track_b(entry: dict, form_url: str) -> tuple[str, str]:
+    title = f"[Track B] Feedback: {entry['id']} — {entry['title']}"
+    body = TRACK_B_BODY.format(
         entry_id=entry["id"],
         entry_title=entry["title"],
         file=entry["file"],
@@ -217,9 +228,9 @@ def render_track_a(entry: dict, form_url: str) -> tuple[str, str]:
     )
     return title, body
 
-def render_track_b(entry: dict, form_url: str) -> tuple[str, str]:
-    title = f"[Track B] Feedback: {entry['title']}"
-    body = TRACK_B_BODY.format(
+def render_track_a(entry: dict, form_url: str) -> tuple[str, str]:
+    title = f"[Track A] Feedback: {entry['title']}"
+    body = TRACK_A_BODY.format(
         entry_title=entry["title"],
         file=entry["file"],
         repo=REPO,
@@ -247,12 +258,23 @@ def post_issue(title: str, body: str, labels: list[str], token: str, dry_run: bo
 
 # ---------- Main ----------
 
+def _parse_only_ids(raw: str | None) -> set[str]:
+    """Parse the --only-ids CSV into a set. Empty or None -> empty set (no filter)."""
+    if not raw:
+        return set()
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Create Sprint 2 feedback issues.")
     parser.add_argument("--form-url", required=True, help="Published URL for the Sprint 2 Google Form (single ballot, both tracks)")
     parser.add_argument("--dry-run", action="store_true", help="Render but do not post.")
     parser.add_argument("--issues-file", default=str(ISSUES_PATH), help="Path to issues.json")
     parser.add_argument("--skip-labels", action="store_true", help="Skip the label upsert step.")
+    parser.add_argument("--only-ids", default=None,
+                        help="Comma-separated entry IDs to create (e.g. 'TA-CFAS,TA-NEW1'). "
+                             "When set, only matching entries fire. Labels still upsert. "
+                             "Use for mid-sprint additions without duplicating existing issues.")
     args = parser.parse_args()
 
     token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
@@ -266,30 +288,49 @@ def main() -> int:
         return 1
 
     config = json.loads(issues_file.read_text())
+    only_ids = _parse_only_ids(args.only_ids)
+
+    # Filter both track lists if --only-ids was supplied.
+    track_b = [e for e in config["track_b"] if not only_ids or e["id"] in only_ids]
+    track_a = [e for e in config["track_a"] if not only_ids or e["id"] in only_ids]
+
+    if only_ids:
+        matched = {e["id"] for e in track_b + track_a}
+        unmatched = only_ids - matched
+        if unmatched:
+            print(f"WARNING: --only-ids contained IDs not found in issues.json: {sorted(unmatched)}",
+                  file=sys.stderr)
+        if not matched:
+            print("ERROR: --only-ids filter matched zero entries. Aborting.", file=sys.stderr)
+            return 1
+
     print(f"OWASP Top 10 LLM 2026 — Sprint 2 issue creator (dry_run={args.dry_run})")
     print(f"  repo:     {REPO}")
     print(f"  form url: {args.form_url}")
-    print(f"  track A:  {len(config['track_a'])} issues")
-    print(f"  track B:  {len(config['track_b'])} issues")
+    print(f"  filter:   {sorted(only_ids) if only_ids else '(none — all entries)'}")
+    print(f"  track B:  {len(track_b)} issues")
+    print(f"  track A:  {len(track_a)} issues")
 
     if not args.skip_labels:
         ensure_labels(config["labels"], token or "", args.dry_run)
 
-    print("[track-a] creating issues")
-    for entry in config["track_a"]:
-        title, body = render_track_a(entry, args.form_url)
-        post_issue(title, body, ["sprint-2", "track-a", "feedback", entry["id"]],
-                   token or "", args.dry_run)
-        if not args.dry_run:
-            time.sleep(RATE_PAUSE_SEC)
+    if track_b:
+        print("[track-b] creating issues")
+        for entry in track_b:
+            title, body = render_track_b(entry, args.form_url)
+            post_issue(title, body, ["sprint-2", "track-b", "feedback", entry["id"]],
+                       token or "", args.dry_run)
+            if not args.dry_run:
+                time.sleep(RATE_PAUSE_SEC)
 
-    print("[track-b] creating issues")
-    for entry in config["track_b"]:
-        title, body = render_track_b(entry, args.form_url)
-        post_issue(title, body, ["sprint-2", "track-b", "feedback", entry["id"]],
-                   token or "", args.dry_run)
-        if not args.dry_run:
-            time.sleep(RATE_PAUSE_SEC)
+    if track_a:
+        print("[track-a] creating issues")
+        for entry in track_a:
+            title, body = render_track_a(entry, args.form_url)
+            post_issue(title, body, ["sprint-2", "track-a", "feedback", entry["id"]],
+                       token or "", args.dry_run)
+            if not args.dry_run:
+                time.sleep(RATE_PAUSE_SEC)
 
     print("done.")
     return 0

--- a/2026/polling/scripts/issues.json
+++ b/2026/polling/scripts/issues.json
@@ -7,6 +7,7 @@
     "form": {
       "published_url": "https://docs.google.com/forms/d/e/1FAIpQLSebmFQyJPOMuw1IorHCJ2FdW98ZT2oLNBuVgYqpPoayW9v6ww/viewform",
       "short_url":     "https://forms.gle/jFmqZF1R6k9gCEfi6",
+      "edit_url":      "https://docs.google.com/forms/d/1lNZHaqUQC_A9DJeSy9JJ1FQkzE1T-lA92vbJLoE6K_k/edit",
       "form_id":       "1lNZHaqUQC_A9DJeSy9JJ1FQkzE1T-lA92vbJLoE6K_k",
       "generated":     "May 4, 2026",
       "covers_tracks": ["A", "B"]
@@ -22,8 +23,8 @@
   },
   "labels": [
     {"name": "sprint-2",  "color": "0E8A16", "description": "Sprint 2 — Community Review and Voting (May 4–18, 2026)"},
-    {"name": "track-a",   "color": "1D76DB", "description": "Track A — feedback on existing Top 10 entries"},
-    {"name": "track-b",   "color": "5319E7", "description": "Track B — feedback on new candidate entries"},
+    {"name": "track-a",   "color": "1D76DB", "description": "Track A — feedback on new candidate entries"},
+    {"name": "track-b",   "color": "5319E7", "description": "Track B — feedback on existing Top 10 entries"},
     {"name": "feedback",  "color": "FBCA04", "description": "Community feedback on a specific entry"},
     {"name": "LLM01",     "color": "C5DEF5", "description": "LLM01 Prompt Injection"},
     {"name": "LLM02",     "color": "C5DEF5", "description": "LLM02 Sensitive Information Disclosure"},
@@ -35,16 +36,26 @@
     {"name": "LLM08",     "color": "C5DEF5", "description": "LLM08 Vector and Embedding Weaknesses"},
     {"name": "LLM09",     "color": "C5DEF5", "description": "LLM09 Misinformation"},
     {"name": "LLM10",     "color": "C5DEF5", "description": "LLM10 Unbounded Consumption"},
-    {"name": "TB-CFAS",   "color": "D4C5F9", "description": "Compositional Fine-Tuning Alignment Subversion"},
-    {"name": "TB-CMSB",   "color": "D4C5F9", "description": "Cross-Modal Safety Bypass"},
-    {"name": "TB-ITSC",   "color": "D4C5F9", "description": "Inference-Time Side-Channel Disclosure"},
-    {"name": "TB-MCPX",   "color": "D4C5F9", "description": "MCP Tool Interface Exploitation"},
-    {"name": "TB-MMIS",   "color": "D4C5F9", "description": "Model Misalignment"},
-    {"name": "TB-MSDA",   "color": "D4C5F9", "description": "Model Scheming and Deceptive Alignment"},
-    {"name": "TB-SICG",   "color": "D4C5F9", "description": "Systemic Insecure Code Generation"},
-    {"name": "TB-WLLA",   "color": "D4C5F9", "description": "Weaponized LLM Abuse"}
+    {"name": "TA-CFAS",   "color": "D4C5F9", "description": "Compositional Fine-Tuning Alignment Subversion"},
+    {"name": "TA-CMSB",   "color": "D4C5F9", "description": "Cross-Modal Safety Bypass"},
+    {"name": "TA-ITSC",   "color": "D4C5F9", "description": "Inference-Time Side-Channel Disclosure"},
+    {"name": "TA-MCPX",   "color": "D4C5F9", "description": "MCP Tool Interface Exploitation"},
+    {"name": "TA-MMIS",   "color": "D4C5F9", "description": "Model Misalignment"},
+    {"name": "TA-MSDA",   "color": "D4C5F9", "description": "Model Scheming and Deceptive Alignment"},
+    {"name": "TA-SICG",   "color": "D4C5F9", "description": "Systemic Insecure Code Generation"},
+    {"name": "TA-WLLA",   "color": "D4C5F9", "description": "Weaponized LLM Abuse"}
   ],
   "track_a": [
+    {"id": "TA-CFAS", "title": "Compositional Fine-Tuning Alignment Subversion", "file": "compositional-finetuning-alignment-subversion.md"},
+    {"id": "TA-CMSB", "title": "Cross-Modal Safety Bypass",                       "file": "cross-modal-safety-bypass.md"},
+    {"id": "TA-ITSC", "title": "Inference-Time Side-Channel Disclosure",          "file": "inference-time-side-channel-disclosure.md"},
+    {"id": "TA-MCPX", "title": "MCP Tool Interface Exploitation",                 "file": "mcp-tool-interface-exploitation.md"},
+    {"id": "TA-MMIS", "title": "Model Misalignment",                              "file": "model-misalignment.md"},
+    {"id": "TA-MSDA", "title": "Model Scheming and Deceptive Alignment",          "file": "model-scheming-and-deceptive-alignment.md"},
+    {"id": "TA-SICG", "title": "Systemic Insecure Code Generation",               "file": "systemic-insecure-code-generation.md"},
+    {"id": "TA-WLLA", "title": "Weaponized LLM Abuse",                            "file": "weaponized-llm-abuse.md"}
+  ],
+  "track_b": [
     {"id": "LLM01", "title": "Prompt Injection",                       "file": "LLM01_PromptInjection.md"},
     {"id": "LLM02", "title": "Sensitive Information Disclosure",       "file": "LLM02_SensitiveInformationDisclosure.md"},
     {"id": "LLM03", "title": "Supply Chain",                           "file": "LLM03_SupplyChain.md"},
@@ -55,15 +66,5 @@
     {"id": "LLM08", "title": "Vector and Embedding Weaknesses",        "file": "LLM08_VectorAndEmbeddingWeaknesses.md"},
     {"id": "LLM09", "title": "Misinformation",                         "file": "LLM09_Misinformation.md"},
     {"id": "LLM10", "title": "Unbounded Consumption",                  "file": "LLM10_UnboundedConsumption.md"}
-  ],
-  "track_b": [
-    {"id": "TB-CFAS", "title": "Compositional Fine-Tuning Alignment Subversion", "file": "compositional-finetuning-alignment-subversion.md"},
-    {"id": "TB-CMSB", "title": "Cross-Modal Safety Bypass",                       "file": "cross-modal-safety-bypass.md"},
-    {"id": "TB-ITSC", "title": "Inference-Time Side-Channel Disclosure",          "file": "inference-time-side-channel-disclosure.md"},
-    {"id": "TB-MCPX", "title": "MCP Tool Interface Exploitation",                 "file": "mcp-tool-interface-exploitation.md"},
-    {"id": "TB-MMIS", "title": "Model Misalignment",                              "file": "model-misalignment.md"},
-    {"id": "TB-MSDA", "title": "Model Scheming and Deceptive Alignment",          "file": "model-scheming-and-deceptive-alignment.md"},
-    {"id": "TB-SICG", "title": "Systemic Insecure Code Generation",               "file": "systemic-insecure-code-generation.md"},
-    {"id": "TB-WLLA", "title": "Weaponized LLM Abuse",                            "file": "weaponized-llm-abuse.md"}
   ]
 }

--- a/2026/polling/scripts/sync_sprint2.py
+++ b/2026/polling/scripts/sync_sprint2.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+"""
+OWASP Top 10 for LLM Applications — 2026 Update
+sync_sprint2.py — Reconcile Sprint 2 state with the REMOTE GitHub repo.
+
+Owner:   Rock Lambros (rock@rockcyber.ai)
+Version: 1.0
+Repo:    GenAI-Security-Project/GenAI-LLM-Top10
+
+WHAT THIS DOES
+  Reads everything from the REMOTE repo at run time:
+    - 2026/                          (existing entries: LLM01_*.md ... LLM10_*.md)
+    - 2026/new_entry_candidates/     (Track A candidates: *.md)
+    - 2026/polling/scripts/issues.json  (the registry baseline)
+
+  Computes a fresh registry from the markdown source-of-truth, diffs it
+  against the remote registry, and produces a new local issues.json plus
+  the GitHub issue mutations needed to bring the live world in sync.
+
+  Auto-generates stable TA-XXXX IDs for new candidates (preserving any
+  IDs already in the registry). Updates existing GitHub issues for
+  renamed/edited entries (PATCH title and body). Creates new GitHub
+  issues for newly added candidates. Skips unchanged entries.
+
+  Source of truth: REMOTE main, every run.
+  Local registry:  polling/scripts/issues.json — write-only output.
+
+WHY FULLY REMOTE
+  Multiple team members can push entry edits to main concurrently. Your
+  local clone may be stale even if you just pulled. Reading the registry
+  from REMOTE ensures the diff reflects whatever main looks like at the
+  exact moment the script runs, not whatever your local cache last saw.
+
+USAGE
+  export GH_TOKEN=$(gh auth token)
+
+  # Preview what would change without modifying anything:
+  python3 sync_sprint2.py --dry-run
+
+  # Apply the reconciliation:
+  python3 sync_sprint2.py
+
+  # After applying, commit issues.json and push so Apps Script can fetch:
+  git add 2026/polling/scripts/issues.json
+  git commit -m "Sprint 2: sync entry registry"
+  git push
+
+  # Then in Apps Script, run rebuildSprintTwoFormDynamic() to refresh
+  # the form. URL stays the same.
+
+OPTIONS
+  --dry-run         Show diff and proposed changes without writing or firing
+  --no-fire         Update issues.json but skip firing new GitHub issues
+  --branch BRANCH   Read from a branch other than main (default: main)
+  --no-write        Skip writing to issues.json (useful with --no-fire to
+                    just see what's on remote)
+
+EXIT CODES
+  0  success
+  1  configuration error (no token, can't reach API, etc.)
+  2  GitHub API error during reconciliation or firing
+
+DEPENDENCIES
+  Python 3.9+ stdlib only. No third-party packages.
+  Imports issue-firing helpers from create_issues.py (same directory).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+# Reuse helpers from create_issues so the issue body templates and label
+# upsert logic stay in one place.
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+import create_issues  # type: ignore  # noqa: E402
+
+# ---------- Configuration ----------
+
+REPO = "GenAI-Security-Project/GenAI-LLM-Top10"
+API_BASE = "https://api.github.com"
+RAW_BASE = "https://raw.githubusercontent.com"
+TIMEOUT_SEC = 30
+RATE_PAUSE_SEC = 1.0
+
+ISSUES_PATH = SCRIPT_DIR / "issues.json"
+
+EXISTING_DIR_PATH = "2026"
+CANDIDATE_DIR_PATH = "2026/new_entry_candidates"
+REGISTRY_REPO_PATH = "2026/polling/scripts/issues.json"
+
+# Existing entries are LLM01..LLM10. LLM00_Preface and similar non-votable
+# files are excluded.
+EXISTING_FILE_RE = re.compile(r"^(LLM(?:0[1-9]|10))_.*\.md$")
+
+# Filenames in the candidate directory we should ignore (templates, hidden, etc.)
+CANDIDATE_IGNORE = {"_template.md", ".gitkeep"}
+
+# Label color for new auto-created TB candidate labels.
+TB_LABEL_COLOR = "D4C5F9"
+
+# ---------- HTTP ----------
+
+def _request(method: str, url: str, token: str | None,
+             body: dict | None = None) -> tuple[int, Any, dict]:
+    """Returns (status, parsed_body, headers_dict)."""
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    req.add_header("User-Agent", "owasp-llm-top10-sprint2-sync/1.0")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+            raw = resp.read().decode("utf-8")
+            parsed = json.loads(raw) if raw and resp.headers.get("Content-Type", "").startswith("application/json") else raw
+            return resp.status, parsed, dict(resp.headers)
+    except urllib.error.HTTPError as e:
+        try:
+            err_body = json.loads(e.read().decode("utf-8") or "null")
+        except Exception:
+            err_body = {"message": str(e)}
+        return e.code, err_body, dict(e.headers or {})
+
+
+def _raw_fetch(url: str, token: str | None) -> str:
+    """Fetch a raw URL (e.g. raw.githubusercontent.com). Returns text body."""
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("User-Agent", "owasp-llm-top10-sprint2-sync/1.0")
+    with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+        return resp.read().decode("utf-8")
+
+
+# ---------- Remote repo readers ----------
+
+def list_directory(path: str, branch: str, token: str | None) -> list[dict]:
+    """List files in a repo directory via the GitHub Contents API."""
+    url = f"{API_BASE}/repos/{REPO}/contents/{urllib.parse.quote(path)}?ref={urllib.parse.quote(branch)}"
+    status, body, _ = _request("GET", url, token)
+    if status != 200:
+        print(f"ERROR listing {path} on {branch}: status {status} body {body}", file=sys.stderr)
+        sys.exit(2)
+    return [item for item in body if isinstance(item, dict)]
+
+
+def fetch_markdown(path: str, branch: str, token: str | None) -> str:
+    """Fetch the raw text of a markdown file from the repo."""
+    url = f"{RAW_BASE}/{REPO}/{branch}/{urllib.parse.quote(path)}"
+    return _raw_fetch(url, token)
+
+
+def fetch_remote_registry(branch: str, token: str | None) -> dict | None:
+    """Fetch issues.json from the remote repo. Returns None if missing or
+    invalid (e.g., first run before registry was committed)."""
+    try:
+        url = f"{RAW_BASE}/{REPO}/{branch}/{urllib.parse.quote(REGISTRY_REPO_PATH)}"
+        text = _raw_fetch(url, token)
+        return json.loads(text)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise
+    except json.JSONDecodeError as e:
+        print(f"WARNING: remote {REGISTRY_REPO_PATH} is invalid JSON: {e}", file=sys.stderr)
+        return None
+
+
+# ---------- Entry parsing ----------
+
+_HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*#*\s*$")
+
+
+def parse_first_heading(text: str) -> str:
+    """Extract the first markdown heading at any level (#, ##, ### etc).
+    Returns empty string if no heading found."""
+    for line in text.splitlines():
+        m = _HEADING_RE.match(line.strip())
+        if m:
+            return m.group(1).strip()
+    return ""
+
+
+def humanize_existing_title(filename: str, heading: str, entry_id: str) -> str:
+    """Extract the human title from an existing-entry heading.
+    Handles formats:
+      'LLM01:2026 Prompt Injection'  -> 'Prompt Injection'
+      'LLM01: 2026 Prompt Injection' -> 'Prompt Injection'
+      'LLM01: Misinformation'        -> 'Misinformation'
+      'LLM01 Prompt Injection'       -> 'Prompt Injection'
+      'Prompt Injection'             -> 'Prompt Injection'
+    """
+    if not heading:
+        return filename.replace(".md", "").split("_", 1)[-1]
+    # Strip optional 'LLMXX' prefix, optional ':', optional 'YYYY ' year tag.
+    # Capture the rest as the title.
+    m = re.match(rf"^{entry_id}\s*:?\s*(?:\d{{4}}\s+)?(.+)$", heading)
+    if m:
+        return m.group(1).strip()
+    return heading.strip()
+
+
+def filename_to_humanized(filename: str) -> str:
+    """Fallback title from a candidate slug: kebab-case to Title Case."""
+    base = filename.replace(".md", "")
+    words = base.replace("_", "-").split("-")
+    return " ".join(w.capitalize() for w in words if w)
+
+
+def slug_to_tb_id_base(slug: str) -> str:
+    """Generate a base TA-XXXX ID from a candidate filename slug.
+    First letter of up to 4 words. May collide; caller resolves."""
+    words = [w for w in re.split(r"[-_]", slug) if w]
+    initials = "".join(w[0] for w in words[:4]).upper()
+    if len(initials) < 2:
+        initials = (slug[:4] or "X").upper()
+    return f"TB-{initials}"
+
+
+def assign_candidate_id(filename: str, known: dict[str, str], used: set[str]) -> str:
+    """Use the existing ID if known, otherwise auto-generate with collision resolution."""
+    if filename in known:
+        return known[filename]
+    base = slug_to_tb_id_base(filename.replace(".md", ""))
+    eid = base
+    suffix = 2
+    while eid in used:
+        eid = f"{base}{suffix}"
+        suffix += 1
+    return eid
+
+
+# ---------- Remote -> registry ----------
+
+def load_existing_from_remote(branch: str, token: str | None) -> list[dict]:
+    """Read existing entries (LLM01..LLM10) from remote 2026/.
+    Excludes LLM00_Preface.md and any non-LLMXX files."""
+    items = list_directory(EXISTING_DIR_PATH, branch, token)
+    entries: list[dict] = []
+    for item in items:
+        if item.get("type") != "file":
+            continue
+        name = item["name"]
+        m = EXISTING_FILE_RE.match(name)
+        if not m:
+            continue
+        eid = m.group(1)
+        text = fetch_markdown(f"{EXISTING_DIR_PATH}/{name}", branch, token)
+        heading = parse_first_heading(text)
+        title = humanize_existing_title(name, heading, eid)
+        entries.append({"id": eid, "title": title, "file": name})
+    entries.sort(key=lambda e: e["id"])
+    return entries
+
+
+def load_candidates_from_remote(branch: str, token: str | None,
+                                known: dict[str, str]) -> tuple[list[dict], list[str]]:
+    """Read Track A candidates from remote 2026/new_entry_candidates/.
+    Returns (entries, warnings)."""
+    items = list_directory(CANDIDATE_DIR_PATH, branch, token)
+    entries: list[dict] = []
+    warnings: list[str] = []
+    used_ids = set(known.values())
+
+    for item in items:
+        if item.get("type") != "file":
+            continue
+        name = item["name"]
+        if name in CANDIDATE_IGNORE or name.startswith("."):
+            continue
+        if not name.endswith(".md"):
+            continue
+
+        text = fetch_markdown(f"{CANDIDATE_DIR_PATH}/{name}", branch, token)
+        heading = parse_first_heading(text)
+        title = heading or filename_to_humanized(name)
+
+        eid = assign_candidate_id(name, known, used_ids)
+        used_ids.add(eid)
+        if name not in known:
+            warnings.append(f"NEW candidate: {name} -> {eid} ({title})")
+
+        entries.append({"id": eid, "title": title, "file": name})
+    entries.sort(key=lambda e: e["id"])
+    return entries, warnings
+
+
+# ---------- Reconciliation ----------
+
+def _diff_track(local: list[dict], current: list[dict]) -> tuple[list[dict], list[tuple[dict, dict]], list[dict]]:
+    """Diff one track. Keys by entry ID (stable) so file renames register
+    as a 'changed' rather than add+remove. Returns (new, changed, removed)."""
+    cur_by_id = {e["id"]: e for e in current}
+    local_by_id = {e["id"]: e for e in local}
+
+    new = [e for e in local if e["id"] not in cur_by_id]
+
+    changed: list[tuple[dict, dict]] = []
+    for e in local:
+        if e["id"] in cur_by_id:
+            old = cur_by_id[e["id"]]
+            if (old.get("file") != e["file"]
+                    or old.get("title") != e["title"]):
+                changed.append((old, e))
+
+    removed = [e for e in current if e["id"] not in local_by_id]
+
+    return new, changed, removed
+
+
+def reconcile(local_b: list[dict], local_a: list[dict], config: dict) -> dict:
+    """Compute the diff between remote-derived state and the current registry."""
+    new_b, changed_b, removed_b = _diff_track(local_b, config.get("track_b", []))
+    new_a, changed_a, removed_a = _diff_track(local_a, config.get("track_a", []))
+    return {
+        "new_b": new_b, "new_a": new_a,
+        "changed_b": changed_b, "changed_a": changed_a,
+        "removed_b": removed_b, "removed_a": removed_a,
+    }
+
+
+# ---------- GitHub issue lookup ----------
+
+def fetch_issues_with_label(label: str, token: str) -> list[dict]:
+    """Page through issues with given label (open + closed)."""
+    issues: list[dict] = []
+    page = 1
+    while True:
+        url = (f"{API_BASE}/repos/{REPO}/issues?"
+               f"labels={urllib.parse.quote(label)}&state=all&per_page=100&page={page}")
+        status, body, _ = _request("GET", url, token)
+        if status != 200:
+            print(f"ERROR fetching issues with label {label}: {status} {body}", file=sys.stderr)
+            sys.exit(2)
+        if not isinstance(body, list) or not body:
+            break
+        issues.extend(body)
+        if len(body) < 100:
+            break
+        page += 1
+    # GitHub /issues returns PRs too; filter them out
+    return [i for i in issues if "pull_request" not in i]
+
+
+def covered_entry_ids(issues: list[dict]) -> set[str]:
+    """Extract entry-ID labels (LLM01-10 or TA-XXXX) from a list of issues."""
+    covered: set[str] = set()
+    for issue in issues:
+        for label in issue.get("labels", []):
+            name = label["name"] if isinstance(label, dict) else label
+            if re.match(r"^(LLM\d{2}|TB-[A-Z0-9]+)$", name):
+                covered.add(name)
+    return covered
+
+
+def issues_by_entry_id(issues: list[dict]) -> dict[str, dict]:
+    """Map entry ID -> issue dict. If multiple issues share the same entry
+    label, the first one wins (lowest ID, since GitHub returns newest first
+    by default we explicitly sort)."""
+    issues_sorted = sorted(issues, key=lambda i: i.get("number", 0))
+    by_id: dict[str, dict] = {}
+    for issue in issues_sorted:
+        for label in issue.get("labels", []):
+            name = label["name"] if isinstance(label, dict) else label
+            if re.match(r"^(LLM\d{2}|TB-[A-Z0-9]+)$", name) and name not in by_id:
+                by_id[name] = issue
+    return by_id
+
+
+def patch_issue(number: int, title: str, body: str, token: str) -> bool:
+    """PATCH an existing issue's title and body. Returns True on success."""
+    url = f"{API_BASE}/repos/{REPO}/issues/{number}"
+    status, resp, _ = _request("PATCH", url, token, {"title": title, "body": body})
+    if status != 200:
+        print(f"    ! patch #{number} failed: status {status} body {resp}", file=sys.stderr)
+        return False
+    return True
+
+
+# ---------- Output ----------
+
+def print_diff(diff: dict, warnings: list[str]) -> bool:
+    """Print the diff. Returns True if there are changes to apply."""
+    has_changes = any([diff["new_b"], diff["new_a"],
+                       diff["changed_b"], diff["changed_a"],
+                       diff["removed_b"], diff["removed_a"]])
+
+    print("=" * 60)
+    print("RECONCILIATION DIFF")
+    print("=" * 60)
+
+    if warnings:
+        print("\nWARNINGS:")
+        for w in warnings:
+            print(f"  - {w}")
+
+    def show_added(label, lst):
+        if lst:
+            print(f"\n[+] NEW in {label}:")
+            for e in lst:
+                print(f"      {e['id']:8s} {e['title']}  ({e['file']})")
+
+    def show_changed(label, lst):
+        if lst:
+            print(f"\n[~] CHANGED in {label}:")
+            for old, new in lst:
+                print(f"      {new['id']}:")
+                if old.get("file") != new["file"]:
+                    print(f"        file:  {old.get('file','?')} -> {new['file']}")
+                if old.get("title") != new["title"]:
+                    print(f"        title: {old.get('title','?')!r}")
+                    print(f"            -> {new['title']!r}")
+
+    def show_removed(label, lst):
+        if lst:
+            print(f"\n[-] REMOVED from {label} (file no longer in remote):")
+            for e in lst:
+                print(f"      {e['id']:8s} {e['title']}  ({e['file']})")
+            print(f"      WARNING: removals are NOT auto-applied. Verify manually.")
+
+    show_added("Track B", diff["new_b"])
+    show_added("Track A", diff["new_a"])
+    show_changed("Track B", diff["changed_b"])
+    show_changed("Track A", diff["changed_a"])
+    show_removed("Track B", diff["removed_b"])
+    show_removed("Track A", diff["removed_a"])
+
+    if not has_changes and not warnings:
+        print("\nNo changes. Remote state matches local registry.")
+
+    print("=" * 60)
+    return has_changes
+
+
+# ---------- Apply changes ----------
+
+def build_updated_config(local_b: list[dict], local_a: list[dict], config: dict) -> dict:
+    """Build a new config dict with updated track_b and track_a, plus any new labels."""
+    new_config = dict(config)
+    new_config["track_b"] = local_b
+    new_config["track_a"] = local_a
+
+    # Ensure each entry ID has a corresponding label entry
+    existing_label_names = {l["name"] for l in config.get("labels", [])}
+    new_labels = list(config.get("labels", []))
+    for e in local_a:
+        if e["id"] not in existing_label_names:
+            new_labels.append({
+                "name": e["id"],
+                "color": TB_LABEL_COLOR,
+                "description": e["title"],
+            })
+            existing_label_names.add(e["id"])
+    # Update label descriptions if title changed
+    name_to_label = {l["name"]: l for l in new_labels}
+    for e in local_a:
+        if e["id"] in name_to_label:
+            name_to_label[e["id"]]["description"] = e["title"]
+
+    new_config["labels"] = new_labels
+    return new_config
+
+
+def write_config(config: dict) -> None:
+    ISSUES_PATH.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+
+def sync_github_issues(config: dict, diff: dict, form_url: str, token: str,
+                       dry_run: bool, existing_issues: list[dict]) -> dict:
+    """Two-phase sync against GitHub issues:
+       1. UPDATE existing issues for entries that changed (rename, title edit)
+       2. CREATE issues for entries that don't have one yet
+    Returns a summary dict.
+    """
+    summary: dict[str, list[str]] = {
+        "updated": [],
+        "created": [],
+        "skipped_unchanged": [],
+        "missing_after_rename": [],
+    }
+
+    if not dry_run:
+        # Idempotent label upsert
+        create_issues.ensure_labels(config["labels"], token, dry_run=False)
+
+    issue_by_id = issues_by_entry_id(existing_issues)
+
+    # ---- Phase 1: UPDATE changed entries ----
+    changed_entries: list[tuple[str, dict, dict]] = []
+    for old, new in diff.get("changed_b", []):
+        changed_entries.append(("a", old, new))
+    for old, new in diff.get("changed_a", []):
+        changed_entries.append(("b", old, new))
+
+    if changed_entries:
+        print("\n[issues] updating existing issues for changed entries...")
+        for track, old, new in changed_entries:
+            issue = issue_by_id.get(new["id"])
+            if not issue:
+                summary["missing_after_rename"].append(new["id"])
+                print(f"    ! {new['id']} marked changed but no existing issue with that label found. Will create below.")
+                continue
+            renderer = create_issues.render_track_b if track == "a" else create_issues.render_track_a
+            new_title, new_body = renderer(new, form_url)
+            issue_num = issue["number"]
+            if dry_run:
+                print(f"    [dry-run] would update #{issue_num}:")
+                print(f"        title: {issue.get('title','?')!r}")
+                print(f"            -> {new_title!r}")
+            else:
+                if patch_issue(issue_num, new_title, new_body, token):
+                    print(f"    ~ updated #{issue_num}: {new_title}")
+                    time.sleep(RATE_PAUSE_SEC)
+            summary["updated"].append(new["id"])
+
+    # ---- Phase 2: CREATE issues for entries with no coverage ----
+    covered = set(issue_by_id.keys())
+    print("\n[issues] firing for entries missing a GitHub issue...")
+    for entry in config["track_b"]:
+        if entry["id"] in covered:
+            if entry["id"] not in summary["updated"]:
+                summary["skipped_unchanged"].append(entry["id"])
+            continue
+        title, body = create_issues.render_track_b(entry, form_url)
+        labels = ["sprint-2", "track-b", "feedback", entry["id"]]
+        if dry_run:
+            print(f"    [dry-run] would create: {title}")
+        else:
+            create_issues.post_issue(title, body, labels, token, dry_run=False)
+            time.sleep(RATE_PAUSE_SEC)
+        summary["created"].append(entry["id"])
+
+    for entry in config["track_a"]:
+        if entry["id"] in covered:
+            if entry["id"] not in summary["updated"]:
+                summary["skipped_unchanged"].append(entry["id"])
+            continue
+        title, body = create_issues.render_track_a(entry, form_url)
+        labels = ["sprint-2", "track-a", "feedback", entry["id"]]
+        if dry_run:
+            print(f"    [dry-run] would create: {title}")
+        else:
+            create_issues.post_issue(title, body, labels, token, dry_run=False)
+            time.sleep(RATE_PAUSE_SEC)
+        summary["created"].append(entry["id"])
+
+    return summary
+
+
+# ---------- Main ----------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Reconcile Sprint 2 with the remote repo.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show diff and proposed actions without writing or firing.")
+    parser.add_argument("--no-fire", action="store_true",
+                        help="Update issues.json but skip firing new GitHub issues.")
+    parser.add_argument("--no-write", action="store_true",
+                        help="Do not write to issues.json (useful with --no-fire to inspect remote).")
+    parser.add_argument("--branch", default="main",
+                        help="Read from a branch other than main (default: main).")
+    parser.add_argument("--form-url", default=None,
+                        help="Override Form URL for new issues. Defaults to "
+                             "issues.json _meta.form.published_url.")
+    args = parser.parse_args()
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("WARNING: no GH_TOKEN or GITHUB_TOKEN set. "
+              "Anonymous reads work for public repos but rate limits will apply, "
+              "and writes will fail.", file=sys.stderr)
+
+    print(f"Sprint 2 sync (branch={args.branch}, dry_run={args.dry_run})")
+    print(f"  repo:     {REPO}")
+    print(f"  registry: {ISSUES_PATH}  (write target)")
+    print()
+
+    # Phase 1: read remote state — both the markdown source-of-truth AND the registry
+    print(f"[remote] fetching registry from {REGISTRY_REPO_PATH} on {args.branch}...")
+    config = fetch_remote_registry(args.branch, token)
+    if config is None:
+        # First run, or registry not yet committed. Fall back to a minimal
+        # config so the rest of the pipeline can still run.
+        if ISSUES_PATH.exists():
+            print(f"         remote registry missing; falling back to local {ISSUES_PATH}")
+            config = json.loads(ISSUES_PATH.read_text(encoding="utf-8"))
+        else:
+            print(f"         remote registry missing AND no local fallback. Bootstrapping empty.")
+            config = {"_meta": {}, "labels": [], "track_b": [], "track_a": []}
+    else:
+        print(f"         pulled remote registry: "
+              f"{len(config.get('track_b', []))} Track B, "
+              f"{len(config.get('track_a', []))} Track A")
+
+    print("[remote] listing existing entries...")
+    local_b = load_existing_from_remote(args.branch, token)
+    print(f"         found {len(local_b)} entries in {EXISTING_DIR_PATH}/")
+
+    print("[remote] listing candidates...")
+    known_ids = {e["file"]: e["id"] for e in config.get("track_a", [])}
+    local_a, warnings = load_candidates_from_remote(args.branch, token, known_ids)
+    print(f"         found {len(local_a)} entries in {CANDIDATE_DIR_PATH}/")
+
+    # Phase 2: diff
+    diff = reconcile(local_b, local_a, config)
+    has_changes = print_diff(diff, warnings)
+
+    # Phase 3: build updated config
+    new_config = build_updated_config(local_b, local_a, config)
+
+    # Phase 4: write registry
+    if not has_changes:
+        print("\nRegistry already in sync. No write needed.")
+    elif args.no_write:
+        print("\n[--no-write] skipping registry update.")
+    elif args.dry_run:
+        print("\n[--dry-run] would write updated registry to issues.json.")
+    else:
+        write_config(new_config)
+        print(f"\n[write] updated {ISSUES_PATH}")
+
+    # Phase 5: fire missing issues
+    if args.no_fire:
+        print("\n[--no-fire] skipping issue creation.")
+        return 0
+
+    if not token and not args.dry_run:
+        print("\nERROR: cannot fire issues without GH_TOKEN. "
+              "Run with --no-fire or set GH_TOKEN.", file=sys.stderr)
+        return 1
+
+    form_url = args.form_url or new_config.get("_meta", {}).get("form", {}).get("published_url")
+    if not form_url:
+        print("\nERROR: no form URL available. Pass --form-url or "
+              "ensure _meta.form.published_url is set in issues.json.", file=sys.stderr)
+        return 1
+
+    print(f"\n[issues] checking which entries already have a GitHub issue...")
+    if token:
+        existing = fetch_issues_with_label("sprint-2", token)
+        print(f"         {len(existing)} sprint-2 issues found")
+    else:
+        existing = []
+        print(f"         no token, can't enumerate existing issues "
+              f"(use --dry-run to preview without writes)")
+
+    summary = sync_github_issues(new_config, diff, form_url,
+                                  token or "", args.dry_run, existing)
+
+    print()
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"  Updated existing issues: {len(summary['updated'])} {summary['updated']}")
+    print(f"  Created new issues:      {len(summary['created'])} {summary['created']}")
+    print(f"  Unchanged (skipped):     {len(summary['skipped_unchanged'])}")
+    if summary["missing_after_rename"]:
+        print(f"  WARNING — IDs marked as changed but no existing issue: "
+              f"{summary['missing_after_rename']}")
+        print(f"  These were re-created above (look for '[create]' lines).")
+    print()
+
+    if not args.dry_run and (has_changes or summary["created"] or summary["updated"]):
+        print("NEXT STEPS:")
+        print("  1. git add 2026/polling/scripts/issues.json")
+        print("  2. git commit -m 'Sprint 2: sync entry registry'")
+        print("  3. git push")
+        print("  4. In Apps Script, run rebuildSprintTwoFormDynamic() to refresh the form.")
+        print("     URL stays unchanged.")
+        print("  5. Spot-check the live form, the GitHub issues filter, and the pinned Discussion.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

CONTRIBUTING.md (master) defines:
- **Track A** = NEW entry candidate (in `2026/new_entry_candidates/`)
- **Track B** = UPGRADE existing LLM01–LLM10 entry

The polling subsystem under `2026/polling/` had these labels inverted (Track A was being used for existing-entry feedback; Track B for new candidates). This PR aligns polling with the master spec and bundles in the Sprint 2 scaffolding files that were locally staged.

This is gating the Sprint 2 sync run.

## What changed

### 1. Track A/B label semantics inverted
All polling files updated. Five case variants swapped bidirectionally: `Track A`/`Track B`, `track_a`/`track_b`, `track-a`/`track-b`, `TRACK_A`/`TRACK_B`, `track A`/`track B`. Four internal variable-name suffix pairs swapped together so identifier semantics stay aligned: `local_a`/`local_b`, `new_a`/`new_b`, `changed_a`/`changed_b`, `removed_a`/`removed_b`.

### 2. Entry IDs renamed: TB-XXXX → TA-XXXX
The 8 new-candidate proposals had `TB-` prefixes from the inverted scheme. Renamed across 11 files (53→54 occurrences; the +1 is from `TB-NEW1`-style placeholder examples in code comments).

### 3. `issues.json` structurally swapped
- `track_a` key now binds the 8 TA-* candidates
- `track_b` key now binds the 10 LLM01–LLM10 upgrades
- `track-a` / `track-b` label descriptions updated to match
- 8 `TB-*` label entries renamed to `TA-*`
- `_meta` block (Published URL, Short URL, Form ID, Edit URL, discussion) preserved byte-equal

### 4. Issue templates renamed
`feedback-track-a.yml` ↔ `feedback-track-b.yml` swapped on disk so each filename matches its content. Track A template carries the candidate rubric (**Importance / Clarity / Distinctness** with the overlap-with-existing dropdown); Track B template carries the existing-entry rubric (**Importance / Clarity** only).

### 5. New scaffolding committed for the first time
- `scripts/sync_sprint2.py` — Sprint 2 sync engine (690 lines)
- `RUNBOOK_TOMORROW.md` — operational runbook (464 lines)
- `forms/update_guide.md` — form-update playbook
- `.github/ISSUE_TEMPLATE/{config,feedback-track-a,feedback-track-b}.yml`
- `.gitignore` — excludes `__pycache__`, `.DS_Store`, `.env`

### 6. Stashed local mods folded in
- Form **Edit URL** added to README.md, blueprint.md, and `issues.json._meta.form`
- `rebuildSprintTwoForm()` helper added to `create_form.gs` — updates form items in place on the existing Form ID, **URL never changes**
- `create_issues.py` compatibility tweaks for the rebuild path

## URL preservation guarantee

All **38 occurrences** of the form Published URL, Short URL, Form ID, and Edit URL are byte-equal before/after this PR. The live Google Form on Google's servers is **not modified** by this PR — only the in-repo source of truth changes. A subsequent `rebuildSprintTwoForm()` invocation (during Phase 2 sync) will update the form contents in place without changing the URL.

## Verification

- `python3 -c "import json; json.load(...)"` → schema parses ✓
- `python3 -m py_compile sync_sprint2.py create_issues.py` → compiles ✓
- `grep -rE 'TB-[A-Z]' 2026/polling/` → empty ✓
- `Track A` count: 44 → 62 (mirrors prior `Track B`) ✓
- `Track B` count: 62 → 44 (mirrors prior `Track A`) ✓
- 38 URL occurrences preserved byte-equal ✓
- `feedback-track-a.yml` content: New Candidate Entry + Distinctness ✓
- `feedback-track-b.yml` content: Existing Entry, no Distinctness ✓

## Merge plan

Voting has not started yet, so no GitHub-issue retro-relabel is needed. The next `sync_sprint2.py` run will create the 18 issues with the corrected labels.

Owner authorization: @rocklambros. Author = rocklambros, so cannot self-approve via gh — admin-merge as planned.