### PR TITLE
polling: post-swap follow-up — fix 3 functional bugs and runbook order

### DIFF
--- a/2026/polling/RUNBOOK_TOMORROW.md
+++ b/2026/polling/RUNBOOK_TOMORROW.md
@@ -225,10 +225,10 @@ Click the eye/preview icon (top right of the Forms editor) to see the voter view
 Page through. Confirm:
 
 - "About You" page is intact (affiliation, familiarity, GitHub handle, single-ballot pledge).
-- Track B entries are LLM01 through LLM10.
-- Specifically: any entries that were renamed (e.g., LLM07 if today) show the new title.
 - Track A section appears with the correct number of candidates.
 - New candidates are present.
+- Track B entries are LLM01 through LLM10.
+- Specifically: any entries that were renamed (e.g., LLM07 if today) show the new title.
 
 If anything looks wrong, stop. Don't post comms yet.
 
@@ -251,7 +251,7 @@ Steps:
    print(f'Total sprint-2 issues: {len(issues)}')
    for i in issues:
        labels = [l['name'] for l in i['labels']]
-       entry_id = next((l for l in labels if l.startswith('LLM') or l.startswith('TB-')), '?')
+       entry_id = next((l for l in labels if l.startswith('LLM') or l.startswith('TA-')), '?')
        print(f'  #{i[\"number\"]:4d}  [{entry_id:8s}]  {i[\"title\"]}')
    "
 
@@ -354,7 +354,7 @@ Three quick visual checks before posting comms.
 **Browser, three tabs:**
 
 1. Open the Form's published URL: https://forms.gle/jFmqZF1R6k9gCEfi6
-   - Page through. Confirm Track B and Track A sections are correct.
+   - Page through. Confirm Track A and Track B sections are correct.
 
 2. Open the issues filter: https://github.com/GenAI-Security-Project/GenAI-LLM-Top10/issues?q=is%3Aissue+label%3Asprint-2
    - Eyeball the count and titles. Click into any renamed issue (e.g., LLM07) to confirm the body links to the new file path.

--- a/2026/polling/forms/create_form.gs
+++ b/2026/polling/forms/create_form.gs
@@ -230,18 +230,18 @@ function rebuildSprintTwoFormDynamic() {
     return;
   }
 
-  const remoteA = registry.track_b || [];
-  const remoteB = registry.track_a || [];
+  const remoteA = registry.track_a || [];
+  const remoteB = registry.track_b || [];
   Logger.log('Fetched registry from remote:');
-  Logger.log('  Track B: ' + remoteA.length + ' entries');
-  Logger.log('  Track A: ' + remoteB.length + ' entries');
+  Logger.log('  Track A: ' + remoteA.length + ' entries');
+  Logger.log('  Track B: ' + remoteB.length + ' entries');
 
   // Override the in-script arrays with the remote ones, in place. Note that
   // const-bound arrays can't be reassigned, but we can mutate them.
-  TRACK_B_ENTRIES.length = 0;
-  remoteA.forEach(function (e) { TRACK_B_ENTRIES.push(e); });
   TRACK_A_ENTRIES.length = 0;
-  remoteB.forEach(function (e) { TRACK_A_ENTRIES.push(e); });
+  remoteA.forEach(function (e) { TRACK_A_ENTRIES.push(e); });
+  TRACK_B_ENTRIES.length = 0;
+  remoteB.forEach(function (e) { TRACK_B_ENTRIES.push(e); });
 
   // Hand off to the existing rebuild function
   rebuildSprintTwoForm();

--- a/2026/polling/scripts/sync_sprint2.py
+++ b/2026/polling/scripts/sync_sprint2.py
@@ -221,21 +221,21 @@ def filename_to_humanized(filename: str) -> str:
     return " ".join(w.capitalize() for w in words if w)
 
 
-def slug_to_tb_id_base(slug: str) -> str:
+def slug_to_ta_id_base(slug: str) -> str:
     """Generate a base TA-XXXX ID from a candidate filename slug.
     First letter of up to 4 words. May collide; caller resolves."""
     words = [w for w in re.split(r"[-_]", slug) if w]
     initials = "".join(w[0] for w in words[:4]).upper()
     if len(initials) < 2:
         initials = (slug[:4] or "X").upper()
-    return f"TB-{initials}"
+    return f"TA-{initials}"
 
 
 def assign_candidate_id(filename: str, known: dict[str, str], used: set[str]) -> str:
     """Use the existing ID if known, otherwise auto-generate with collision resolution."""
     if filename in known:
         return known[filename]
-    base = slug_to_tb_id_base(filename.replace(".md", ""))
+    base = slug_to_ta_id_base(filename.replace(".md", ""))
     eid = base
     suffix = 2
     while eid in used:
@@ -362,7 +362,7 @@ def covered_entry_ids(issues: list[dict]) -> set[str]:
     for issue in issues:
         for label in issue.get("labels", []):
             name = label["name"] if isinstance(label, dict) else label
-            if re.match(r"^(LLM\d{2}|TB-[A-Z0-9]+)$", name):
+            if re.match(r"^(LLM\d{2}|TA-[A-Z0-9]+)$", name):
                 covered.add(name)
     return covered
 
@@ -376,7 +376,7 @@ def issues_by_entry_id(issues: list[dict]) -> dict[str, dict]:
     for issue in issues_sorted:
         for label in issue.get("labels", []):
             name = label["name"] if isinstance(label, dict) else label
-            if re.match(r"^(LLM\d{2}|TB-[A-Z0-9]+)$", name) and name not in by_id:
+            if re.match(r"^(LLM\d{2}|TA-[A-Z0-9]+)$", name) and name not in by_id:
                 by_id[name] = issue
     return by_id
 


### PR DESCRIPTION
Followup to #62. The Track-A/B swap there used regex `TB-([A-Z][A-Z0-9]*)` which required an uppercase letter immediately after `TB-`, so any `TB-` followed by `{`, `[`, or quote characters was skipped. Three of those slips were real bugs that would have broken Phase 2.

## Functional fixes (would have broken Phase 2)

1. **`sync_sprint2.py:231`** — ID generator was `return f"TB-{initials}"`. Auto-generated IDs for new candidates would have used the wrong prefix. Fixed to `TA-{initials}`. Also renamed `slug_to_tb_id_base()` → `slug_to_ta_id_base()` and updated the caller.
2. **`sync_sprint2.py:365` and `:379`** — issue-label regex was `r"^(LLM\d{2}|TB-[A-Z0-9]+)$"`. Would never match `TA-*` labels we're now creating. Fixed to `TA-[A-Z0-9]+`.
3. **`RUNBOOK_TOMORROW.md:254`** — Phase 5 spot-check prompt used `l.startswith('TB-')`. Wouldn't detect `TA-*` labels. Fixed to `'TA-'`.

## Hygiene fixes

4. **`forms/create_form.gs:233-244`** — `remoteA` / `remoteB` variable names were semantically inverted post-swap (`remoteA` held Track-B data). The original swap caught `local_a` / `local_b` and similar suffix pairs but missed this camelCase pair. Renamed and reordered so `remoteA` ↔ `registry.track_a` and `remoteB` ↔ `registry.track_b` match the declaration semantics. Functional behavior unchanged.
5. **`RUNBOOK_TOMORROW.md:357` (Phase 7)** — said "Track B and Track A sections". Form builds Track A first (per `buildTrackAEntries` then `buildTrackBEntries` in `createSprintTwoForm`/`rebuildSprintTwoForm`), so voters page through Track A first. Reordered to "Track A and Track B sections".
6. **`RUNBOOK_TOMORROW.md:228-231` (Phase 4.4 spot-check)** — bullets reordered to put Track A items before Track B items, matching actual form section order.

## Verification

- `grep -rn "TB-" 2026/polling/` → empty
- `python3 -m py_compile sync_sprint2.py create_issues.py` → clean
- 3 files changed, +16/-16 (symmetrical because most fixes are renames)

## Merge plan

Author = rocklambros (cannot self-approve via gh) — admin-merge as planned. Sprint 2 launch (Phase 2) needs this merged first.