### PR TITLE
LLM03: update supply-chain entry (model signing, AIBOM, agentic cross-ref, recent CVE scenarios)

### DIFF
--- a/2026/LLM03_SupplyChain.md
+++ b/2026/LLM03_SupplyChain.md
@@ -8,7 +8,7 @@ These external elements can be manipulated through tampering, poisoning, or mali
 
 Creating LLMs is a specialized task that often depends on third-party models and reusable adapters. The rise of open-access LLMs and new fine-tuning methods like LoRA (Low-Rank Adaptation) and PEFT (Parameter-Efficient Fine-Tuning), especially on platforms like Hugging Face, introduce new supply-chain risks. The biggest recent shift is that the supply chain now includes model artifacts, provenance, and conversion/merge workflows as first-class attack surfaces. Finally, the emergence of on-device LLMs increases the attack surface and supply-chain risks for LLM applications.
 
-Some of the risks discussed here are also discussed in "LLM04 Data and Model Poisoning." This entry focuses on the supply-chain aspect of the risks.
+Some of the risks discussed here are also discussed in "LLM04 Data and Model Poisoning." This entry focuses on the supply-chain aspect of the risks. Supply-chain risks specific to agentic applications are covered by ASI04 Agentic Supply Chain Vulnerabilities in the OWASP Top 10 for Agentic Applications.
 A simple threat model can be found [here](https://github.com/jsotiro/ThreatModels/blob/main/LLM%20Threats-LLM%20Supply%20Chain.png).
 
 ### Common Examples of Risks
@@ -28,7 +28,7 @@ Using outdated or deprecated models that are no longer maintained leads to secur
 
 #### 4. Vulnerable Pre-Trained Model
 
-Models are binary black boxes and unlike open source, static inspection can offer little to no security assurances. Vulnerable pre-trained models can contain hidden biases, backdoors, or other malicious features that have not been identified through the safety evaluations of model repositories. Vulnerable models can be created by poisoned datasets, direct model tampering, or malicious re-publication of a trusted model.
+Models are binary black boxes and unlike open source, static inspection can offer little to no security assurances. Vulnerable pre-trained models can contain hidden biases, backdoors, or other malicious features that have not been identified through the safety evaluations of model repositories. Vulnerable models can be created by poisoned datasets, direct model tampering, or malicious re-publication of a trusted model. Migrating away from unsafe serialization formats such as Python pickle, which can execute arbitrary code on load, reduces but does not eliminate this risk: a backdoor can be embedded directly in a model's computational graph and persist in formats widely considered safe, such as ONNX.
 
 #### 5. Weak Model Provenance
 
@@ -60,9 +60,9 @@ When models, adapters, datasets, and conversion outputs are not signed or hash-p
 2. Understand and apply the mitigations found in the OWASP Top Ten's "A06:2021 – Vulnerable and Outdated Components." This includes vulnerability scanning, management, and patching components. For development environments with access to sensitive data, apply these controls there too.
    (Ref. link: [A06:2021 – Vulnerable and Outdated Components](https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/))
 3. Apply comprehensive AI red teaming and evaluations when selecting third-party models. Use extensive AI red teaming to evaluate the model, especially for the use cases you are planning to support.
-4. Maintain an up-to-date inventory of components using a Software Bill of Materials (SBOM) to ensure you have an accurate and signed inventory, preventing tampering with deployed packages. Extend this to AI BOMs and ML SBOMs for models, adapters, and datasets.
+4. Maintain an up-to-date inventory of components using a Software Bill of Materials (SBOM) to ensure you have an accurate and signed inventory, preventing tampering with deployed packages. Extend this to AI BOMs (AIBOMs) and ML SBOMs for models, adapters, and datasets, evaluating options such as the OWASP CycloneDX ML-BOM and the OWASP AIBOM project.
 5. To mitigate AI licensing risks, create an inventory of all licenses involved using BOMs and conduct regular audits of all software, tools, models, and datasets, ensuring compliance and transparency.
-6. Only use models from verifiable sources and use third-party model integrity checks with signing and file hashes to compensate for the lack of strong model provenance. Similarly, use code signing for externally supplied code.
+6. Only use models from verifiable sources and use third-party model integrity checks with signing and file hashes to compensate for the lack of strong model provenance. Cryptographic model signing backed by a transparency log (for example, the OpenSSF Model Signing project and Sigstore) binds a model artifact to a signer identity and is preferable to relying on reproducible builds, which are not guaranteed for model training. Note that signing proves integrity and origin, not safety: a validly signed model from a compromised or trusted-but-malicious supplier can still be backdoored, so combine signing with provenance policy and behavioral evaluation. For a maturity model of artifact-signing practices, see the Coalition for Secure AI (CoSAI) work on signing ML artifacts. Similarly, use code signing for externally supplied code.
 7. Implement strict monitoring and auditing practices for collaborative model development environments to prevent and quickly detect abuse. Treat model conversion and merge services as high-risk promotion points.
 8. Use anomaly detection and adversarial robustness tests on supplied models and data to help detect tampering and poisoning. This should be part of MLOps and LLM pipelines.
 9. Implement a patching policy to mitigate vulnerable or outdated components. Ensure the application relies on maintained versions of APIs and underlying models.
@@ -73,7 +73,7 @@ When models, adapters, datasets, and conversion outputs are not signed or hash-p
 
 #### Scenario #1: Vulnerable Python Library
 
-An attacker exploits a vulnerable Python library to compromise an LLM app. This can happen when a compromised dependency is introduced into a model development or inference environment, as seen in attacks on the PyPI registry that tricked developers into installing a tampered PyTorch dependency, and in the Shadow Ray attacks against the Ray AI framework where unauthenticated dashboards on production servers were exploited in the wild.
+An attacker exploits a vulnerable Python library to compromise an LLM app. This can happen when a compromised dependency is introduced into a model development or inference environment, as in the December 2022 PyTorch supply-chain attack where a malicious `torchtriton` package on the PyPI registry shadowed the legitimate PyTorch-nightly dependency and exfiltrated data, and in the ShadowRay attacks against the Ray AI framework where the disputed CVE-2023-48022 (unauthenticated dashboards on production servers) was exploited in the wild.
 
 #### Scenario #2: Direct Tampering
 
@@ -123,6 +123,22 @@ An attacker poisons publicly available datasets to create a backdoor when fine-t
 
 An LLM operator changes its T&Cs and privacy policy to require explicit opt-out from using application data for model training, leading to memorization or exposure of sensitive data.
 
+#### Scenario #14: Model Namespace Reuse
+
+An organization deploys a model from a public hub by referencing it solely by its `Author/ModelName` identifier. The original author deletes or transfers the account, freeing the namespace, and an attacker re-registers the same name and publishes a malicious model under the original path. Pipelines and managed model catalogs that resolve the model by name alone then pull the attacker's model, leading to remote code execution. This technique reinforces that trusting a model by name is not a substitute for provenance verification.
+
+#### Scenario #15: Malicious Serialized Model Evading Hub Scanners
+
+An attacker uploads a model whose serialized weights file is crafted to evade the hub's automated malware scanner, for example a corrupted or compression-wrapped pickle stream that executes its payload before the scanner reaches the broken byte and errors out. A victim who loads the model with the default loader triggers arbitrary code execution. This shows that hub-side scanning of serialized models is necessary but not sufficient.
+
+#### Scenario #16: Codeless Backdoor in a "Safe" Model Format
+
+An attacker modifies a model's computational graph to insert logic that activates only on a specific trigger input, then distributes the model in a format widely considered safe from code execution, such as ONNX. Because no executable code is attached and the backdoor lives in the graph itself, format-based "safe loading" controls and serialization scanners do not detect it, and the tampered model passes superficial review before being integrated downstream.
+
+#### Scenario #17: "Safe" Loader and Scanner Bypass
+
+An organization relies on a loader option documented as safe against code execution (for example, loading weights only) or on a scanner-gated ingestion step to accept third-party models. An attacker crafts a model file that defeats the control, bypassing the safe-loader option or evading the scanner through tricks such as file-extension mismatch or archive corruption, and still achieves arbitrary code execution when the model is loaded. Both safe-loader flags and model scanners have had such bypasses assigned CVEs, so treat them as defense-in-depth layers rather than guarantees, alongside provenance verification and keeping loaders and parsers patched.
+
 ### Reference Links
 
 1. [PoisonGPT: How we hid a lobotomized LLM on Hugging Face to spread fake news](https://blog.mithrilsecurity.io/poisongpt-how-we-hid-a-lobotomized-llm-on-hugging-face-to-spread-fake-news)
@@ -135,9 +151,19 @@ An LLM operator changes its T&Cs and privacy policy to require explicit opt-out 
 8. [Thousands of servers hacked due to insecurely deployed Ray AI framework](https://www.csoonline.com/article/2075540/thousands-of-servers-hacked-due-to-insecurely-deployed-ray-ai-framework.html)
 9. [LeftoverLocals: Listening to LLM responses through leaked GPU local memory](https://blog.trailofbits.com/2024/01/16/leftoverlocals-listening-to-llm-responses-through-leaked-gpu-local-memory/)
 10. [LLM Scalability Risk for Agentic-AI and Model Supply Chain Security](https://arxiv.org/abs/2602.19021): **arXiv**
+11. [Model Namespace Reuse: An AI Supply-Chain Attack Exploiting Model Name Trust](https://unit42.paloaltonetworks.com/model-namespace-reuse/): **Unit 42, Palo Alto Networks**
+12. [Malicious ML models discovered on Hugging Face platform (nullifAI)](https://www.reversinglabs.com/blog/rl-identifies-malware-ml-model-hosted-on-hugging-face): **ReversingLabs**
+13. [PyTorch Users at Risk: Unveiling 3 Zero-Day PickleScan Vulnerabilities](https://jfrog.com/blog/unveiling-3-zero-day-vulnerabilities-in-picklescan/): **JFrog**
+14. [PyTorch torch.load weights_only bypass (CVE-2025-32434)](https://github.com/pytorch/pytorch/security/advisories/GHSA-53q9-r3pm-6pq6): **GitHub Security Advisories**
+15. [Inside CVE-2025-1550: Remote Code Execution via Keras Models](https://blog.huntr.com/inside-cve-2025-1550-remote-code-execution-via-keras-models): **huntr**
+16. [ShadowLogic: Persistent No-Code Backdoors in AI Computational Graphs](https://hiddenlayer.com/innovation-hub/shadowlogic/): **HiddenLayer**
+17. [Launch of Model Signing v1.0: OpenSSF AI/ML Working Group Secures the Machine Learning Supply Chain](https://openssf.org/blog/2025/04/04/launch-of-model-signing-v1-0-openssf-ai-ml-working-group-secures-the-machine-learning-supply-chain/): **OpenSSF**
+18. [Coalition for Secure AI Releases Two Actionable Frameworks for AI Model Signing and Incident Response](https://www.oasis-open.org/2025/11/18/coalition-for-secure-ai-releases-two-actionable-frameworks-for-ai-model-signing-and-incident-response/): **OASIS / CoSAI**
+19. [Evolving AI Transparency: The Journey of the AIBOM Generator and Its New Home at OWASP](https://genai.owasp.org/2025/12/18/evolving-ai-transparency-the-journey-of-the-aibom-generator-and-its-new-home-at-owasp/): **OWASP GenAI Security Project**
+20. [OWASP Top 10 for Agentic Applications (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/): **OWASP GenAI Security Project**
 
 ### Related Frameworks and Taxonomies
 
 Refer to this section for comprehensive information, scenario strategies relating to infrastructure deployment, applied environment controls, and other best practices.
 
-- [ML Supply Chain Compromise](https://atlas.mitre.org/techniques/AML.T0010): **MITRE ATLAS**
+- [AI Supply Chain Compromise (AML.T0010)](https://atlas.mitre.org/techniques/AML.T0010): **MITRE ATLAS** — including sub-techniques for Hardware (.000), AI Software (.001), Data (.002), Model (.003), Container Registry (.004), and AI Agent Tool (.005)

--- a/2026/LLM03_SupplyChain.md
+++ b/2026/LLM03_SupplyChain.md
@@ -139,6 +139,10 @@ An attacker modifies a model's computational graph to insert logic that activate
 
 An organization relies on a loader option documented as safe against code execution (for example, loading weights only) or on a scanner-gated ingestion step to accept third-party models. An attacker crafts a model file that defeats the control, bypassing the safe-loader option or evading the scanner through tricks such as file-extension mismatch or archive corruption, and still achieves arbitrary code execution when the model is loaded. Both safe-loader flags and model scanners have had such bypasses assigned CVEs, so treat them as defense-in-depth layers rather than guarantees, alongside provenance verification and keeping loaders and parsers patched.
 
+#### Scenario #18: Compromised Build Pipeline for Model Artifacts
+
+An attacker compromises the CI/CD pipeline an organization uses to fine-tune and publish an LLM, for example through a malicious GitHub Actions dependency, a stolen artifact-registry credential, or a tampered build secret. The next training or packaging run produces a backdoored model artifact. Because the artifact is built and signed by the organization's own release infrastructure, it passes downstream provenance checks, internal attestation, and supply-chain scanners that only flag externally sourced components. The same build-time substitution that affected traditional software supply chains, as in the xz-utils backdoor and the Codecov breach, applies wherever model artifacts are produced by automated pipelines without model-specific integrity controls such as reproducible builds, transparency logs, or post-build behavioral evaluation.
+
 ### Reference Links
 
 1. [PoisonGPT: How we hid a lobotomized LLM on Hugging Face to spread fake news](https://blog.mithrilsecurity.io/poisongpt-how-we-hid-a-lobotomized-llm-on-hugging-face-to-spread-fake-news)


### PR DESCRIPTION
## changes

- **Description**
note that supply-chain risk specific to agentic apps is covered by **`ASI04`** in the `OWASP Top 10 for Agentic Applications`.
- **`Risk #4` (vuln. pre-trained model)**
moving off Python `pickle` reduces but does not eliminate the risk: backdoors can live in a model's **computational graph** and persist in "safe" formats such as **ONNX**.
- **`Mitigation #4`**
point to the `OWASP CycloneDX ML-BOM` and the `OWASP AIBOM` project.
- **`Mitigation #6`**
expand model-signing guidance (`OpenSSF Model Signing` + `Sigstore` transparency log), clarify that **signing proves integrity and origin, not safety**, and reference the **CoSAI** work on signing ML artifacts.
- **`Scenario #1`**
cite the concrete `torchtriton` PyPI dependency-confusion attack and the disputed **ShadowRay (CVE-2023-48022)**.
- **`New scenarios #14–#18`**
compromised build pipeline (@arshi016), model namespace reuse, scanner-evading serialized models, codeless ONNX-graph backdoors, and "safe" loader/scanner bypass.
- **`Reference links 11–20`**
Unit 42, ReversingLabs, JFrog, the PyTorch & Keras advisories, HiddenLayer, OpenSSF, CoSAI/OASIS, `OWASP AIBOM`, and the `OWASP Agentic Top 10`.
- **Related frameworks**
update the `MITRE ATLAS` entry to its current name **"AI Supply Chain Compromise"** and enumerate its sub-techniques (`.000`–`.005`).

--

supersedes:

- https://github.com/OWASP/www-project-top-10-for-large-language-model-applications/pull/849 reference the OWASP Agentic Top 10 and AIBOM, add latest CVEs/scenarios.
- https://github.com/OWASP/www-project-top-10-for-large-language-model-applications/pull/822 compromised build-pipeline scenario, by @arshi016.
- https://github.com/OWASP/www-project-top-10-for-large-language-model-applications/pull/848 `LorA`/`vLMM` typo fixes. Already resolved in the 2026 rewrite (that text was reworded and the typos are gone), so nothing to port.
