### PR TITLE
LLM01: condense final entry (~34% shorter, same coverage)

### DIFF
--- a/2026/final/LLM01_PromptInjection.md
+++ b/2026/final/LLM01_PromptInjection.md
@@ -32,8 +32,6 @@ A user, or an attacker with the user's access path, supplies input that changes 
 
 While prompt injection and jailbreaking are related concepts in LLM security, they are often incorrectly used interchangeably. Prompt injection involves manipulating model responses through specific inputs to alter its behavior, which can include bypassing safety measures. Jailbreaking is a subset of prompt injection where the attacker goal is to make the model violate its safety protocols. Developers can build safeguards into system prompts and input handling to help mitigate prompt injection attacks, but effective prevention of jailbreaking requires ongoing updates to the model's training and safety mechanisms.
 
-
-
 ### Indirect Prompt Injection
 
 The model ingests content from an external source — a web page, a document, an email, a tool response, a retrieved RAG passage, an image, an MCP server's output, a database row, an issue title — that contains data which acts as prompt injection. The user did not supply or see those instructions. The trust profile of the delivery surface (axis (a) of the anatomy) determines what defenses are practical:
@@ -50,19 +48,19 @@ Indirect prompt injection is increasingly used to turn the user's own LLM instan
 
 1. **Direct prompt-input override.** A user-supplied message bypasses the system prompt's role and capability constraints, causing the model to disclose, generate, or act outside its intended scope. The input can be intentional or unintentional; both should be handled.
 
-2. **Indirect injection through retrieved content.** A RAG passage, retrieved web page, document, or email contains attacker-supplied instructions that the model follows when the content reaches the context window. CVE-2024-5184 (EmailGPT, 2024) is an example of this class against a deployed Gmail extension.
+2. **Indirect injection through retrieved content.** A RAG passage, retrieved web page, document, or email contains attacker-supplied instructions that the model follows when the content reaches the context window. CVE-2024-5184 (EmailGPT, 2024) is an example against a deployed Gmail extension.
 
-3. **Trusted-surface indirect injection.** An attacker submits text through a low-privilege channel (issue tracker, customer-feedback form, support ticket) into a location the user's LLM treats as trusted. The LLM operates with the user's elevated credentials and performs privileged actions — exfiltrating private repositories, dumping databases, or modifying IDE configuration — that the attacker could not perform directly. Examples include the GitHub MCP, Supabase MCP, and GitHub Copilot / VS Code (CVE-2025-53773) cases above.
+3. **Trusted-surface indirect injection.** An attacker submits text through a low-privilege channel (issue tracker, feedback form, support ticket) into a location the user's LLM treats as trusted; the LLM then performs privileged actions under the user's credentials — exfiltrating repositories, dumping databases, or modifying IDE configuration — that the attacker could not perform directly (GitHub MCP, Supabase MCP, CVE-2025-53773).
 
-4. **Multimodal and steganographic injection.** Adversarial perturbations invisible to humans are embedded in images, audio waveforms, or video frames; vision and audio encoders extract the payload. All four frontier vision-language models tested in a 2024 oncology-imaging study (Clusmann et al., *Nature Communications*) were susceptible to sub-visual prompt injection.
+4. **Multimodal and steganographic injection.** Adversarial perturbations invisible to humans are embedded in images, audio, or video frames; vision and audio encoders extract the payload. All four frontier vision-language models tested in a 2024 oncology-imaging study (Clusmann et al., *Nature Communications*) were susceptible.
 
-5. **Invisible-character injection and exfiltration.** Tag-block characters (U+E0000–U+E007F), variation-selector characters (U+FE00–U+FE0F), and zero-width characters (U+200B/C/D, U+2060) carry instructions or exfiltrate bytes through text that appears benign in standard rendering. The August 2024 ASCII-smuggling proof-of-concept against Microsoft 365 Copilot demonstrated MFA-code exfiltration from a controlled demo workspace.
+5. **Invisible-character injection and exfiltration.** Tag-block (U+E0000–U+E007F), variation-selector (U+FE00–U+FE0F), and zero-width (U+200B/C/D, U+2060) characters carry instructions or exfiltrate bytes through text that appears benign in standard rendering. The August 2024 ASCII-smuggling PoC against Microsoft 365 Copilot demonstrated MFA-code exfiltration.
 
-6. **Cross-session memory and RAG corpus poisoning.** An adversarial document written into persistent memory (vector store, conversation summary, hosted memory service) or into a RAG corpus influences every future session that reads from the tainted entry. As few as five injected documents achieved 97% attack success on Natural Questions in the PoisonedRAG study (USENIX Security 2025).
+6. **Cross-session memory and RAG corpus poisoning.** An adversarial document written into persistent memory or a RAG corpus influences every future session that reads the tainted entry. As few as five injected documents achieved 97% attack success on Natural Questions (PoisonedRAG, USENIX Security 2025).
 
-7. **Fine-tuning interface as gradient oracle ("fun-tuning").** An attacker with access to a vendor's fine-tuning API submits candidate adversarial inputs paired with a desired malicious target output, reads the per-example loss the API returns, and uses that loss as a gradient surrogate to drive a greedy token search. The optimized payload is then delivered through any of the standard surfaces and produces the attacker-chosen output with high reliability — 65–82% attack success on Gemini in the original paper. This brings white-box-style optimization within reach of closed-weight production deployments.
+7. **Fine-tuning interface as gradient oracle ("fun-tuning").** An attacker abuses a vendor's fine-tuning API — pairing candidate inputs with a target output and reading the returned per-example loss as a gradient surrogate — to optimize a payload that reliably produces attacker-chosen output (65–82% ASR on Gemini in the original paper), bringing white-box-style optimization to closed-weight deployments.
 
-8. **Multilingual, encoded, or low-resource-language payloads.** Translation to low-resource or code-mixed languages reduces classifier accuracy substantially — refusal rates can fall from approximately 79% in English to approximately 23% in some low-resource languages on identical content. Encoding (Base64, ROT13) and emoji-substituted prompts evade text classifiers that have not been trained on the encoding scheme.
+8. **Multilingual, encoded, or low-resource-language payloads.** Translation to low-resource or code-mixed languages sharply reduces classifier accuracy — refusal rates can fall from ~79% (English) to ~23% on identical content — and encodings (Base64, ROT13) or emoji substitution evade classifiers not trained on the scheme.
 
 ---
 
@@ -72,152 +70,59 @@ Prompt injection vulnerabilities are intrinsic to current generative AI: LLMs ma
 
 Most high-impact prompt-injection incidents on record (EchoLeak / CVE-2025-32711; the Amazon Q runtime and supply-chain pair; the Supabase MCP `service_role` exfiltration; GitHub Copilot / CVE-2025-53773) became severe not because the injection itself succeeded but because the injection landed inside a system whose tools, scopes, or output-rendering capabilities let the compromised model act on the attacker's behalf at the user's privilege level. This is the operational relationship between this entry and **LLM06:2025 Excessive Agency**: prompt injection is the input-side compromise, and excessive functionality, permissions, or autonomy are what give that compromise consequences outside the chat window. Simon Willison's "lethal trifecta" (Jun 2025) restates the same structural diagnosis as a pre-deployment check: an agent that can simultaneously (1) access private data, (2) ingest untrusted content, and (3) communicate externally has the conditions for high-impact exploitation, and removing any one leg removes them. Treat LLM01 and LLM06 as a pair when threat-modeling agentic deployments.
 
-The controls below should be applied as defense-in-depth, with no single control treated as sufficient. They include layers that try to reduce injection success (recommended but expected to degrade against adaptive attackers) and layers that bound the blast radius if injection succeeds (the latter are what survive against attackers who can probe the system). For agentic deployments specifically, the capability-budgeting controls (4, 11) are the load-bearing ones — see **LLM06:2025** for the full agency-side treatment. 
+Apply the controls below as defense-in-depth — no single control is sufficient. Some reduce injection success (and are expected to degrade against adaptive attackers); others bound the blast radius once injection succeeds (these are what survive against attackers who can probe the system). For agentic deployments, the least-privilege and capability-budgeting controls (#4, #8) are load-bearing — see **LLM06:2025** for the full agency-side treatment.
 
-#### 1. Constrain what the model is permitted to do by writing an explicit role and capability boundary in the system prompt
+1. **Constrain the model's role and capabilities in the system prompt.** Use declarative allow/deny statements ("assist with X only; do not access Y; do not forward output to external addresses"), not open-ended grants. A partial control only — an attacker who infers the prompt can bypass it (Nasr/Carlini, 2025); pair with the privilege controls in #4.
 
-Write a system prompt that names the model's role, the tasks it may perform, the data it may access, and the actions it must decline. Use declarative, affirmative statements ("You assist with X only; you do not access Y; you do not forward output to external addresses") rather than open-ended capability grants. Treat this as a partial control that reduces blast radius across axis (b) propagation behavior, not a reliable barrier across axis (a) delivery surface: an attacker who knows or guesses the system prompt's structure can craft an injection that satisfies its surface logic while still achieving a malicious goal.
+2. **Define a strict output schema and validate every response in trusted application code** before any downstream system acts on it — structural validation, not a second LLM call. This catches format violations, not semantic manipulation: a schema-valid response can still carry a malicious SQL query or an exfiltration-formatted email body.
 
-**Addresses anatomy axes:** primarily (b) propagation; partial mitigation across (a).
-**Assumes:** you control the system prompt and it reaches the model before user-supplied content; the model is generally instruction-following.
-**Known limits:** adaptive attackers who can observe or infer the system prompt can bypass it (Nasr/Carlini, 2025). Pair with architectural privilege controls (Control 4) so that a bypassed boundary does not grant access to consequential capabilities.
+3. **Filter at every modality boundary — text, image, audio, structured data — not just text.** Run modality-specific classifiers, OCR over images, and transcription over audio, then apply text filters to the extracted content. Semantic filters are evadable by rephrasing or encoding, and accuracy drops for low-resource languages (refusal ~79% English → ~23%; arXiv:2504.11168, 2025).
 
-#### 2. Define a concrete output schema and validate each response against it before acting on the output
+4. **Hold credentials and state-change capability in application code, not the model, and grant least privilege per operation.** Route privileged calls through a deterministic policy engine that re-validates intent and arguments at execution time. NIST AI 100-2 E2025 and the CISA + Five Eyes OT joint guidance (Dec 2025) frame this deterministic mediation as a baseline procurement expectation. Broad "convenience" permissions and multi-agent hops re-introduce the risk downstream.
 
-Specify the exact format of model responses (e.g., a JSON schema with named fields and permitted value ranges) and enforce compliance deterministically in application code before any downstream system consumes the output. Use structural validation rather than relying on a second LLM call to check the first.
+5. **Strip Tag-block (U+E0000–E007F), variation-selector (U+FE00–FE0F), and zero-width (U+200B/C/D, U+2060) characters at every ingest and render boundary.** These are invisible in normal rendering and smuggle instructions or exfiltration bytes; the Aug 2024 M365 Copilot PoC (Embrace The Red) exfiltrated an MFA code this way, and variation-selector variants (2025) cut cost to ~2 characters per byte. Does not stop visible-text payloads or future stego classes.
 
-**Addresses anatomy axes:** primarily (b) propagation — limits the actions an injected instruction can effect downstream.
-**Assumes:** the format is constrained enough that injected instructions cannot be embedded inside a conformant response; validation runs in trusted application code, not inside the LLM.
-**Known limits:** schema validation catches format violations, not semantic manipulation; a structurally valid response can still encode an attacker-chosen action (e.g., a valid JSON object containing a malicious SQL query, a valid email body containing exfiltration-formatted data).
+6. **Pass external content through a structurally separate, provenance-labeled channel** so the model can distinguish data from instructions (StruQ, USENIX Security 2025; "spotlighting," Microsoft Research 2025). This reduces ASR in non-adaptive tests only — an attacker who knows the marking scheme can mimic it, and StruQ was bypassed under adaptive attack (Nasr/Carlini, 2025).
 
-#### 3. Apply input and output filters at every modality boundary — text, image, audio, and structured data — not only at the text layer
+7. **Require explicit human confirmation before any privileged, irreversible, or externally visible action**, surfacing the exact rendered action — not a summary — to the reviewer. Invisible-character smuggling can make the displayed action differ from the executed one (#5), and approval fatigue degrades reviewer judgment at volume.
 
-Define categories of sensitive or prohibited content and enforce filtering at each point where untrusted content enters the model context and where model output exits to downstream systems. Text-only filters are insufficient: vision encoders process image content holistically, and pixel-level steganographic payloads can carry instructions invisible to humans and to text classifiers. Run modality-specific classifiers, OCR over images, and transcription over audio; pass extracted text through the same text-based filters. Filtering accuracy degrades for low-resource languages — refusal rates can fall from ~79% (English) to ~23% (some low-resource languages) on identical content (arXiv:2504.11168, 2025).
+8. **Budget agent capabilities with the Rule of Two as a floor.** Treat simultaneous access to (A) untrusted input, (B) sensitive data, and (C) state change / external comms as high-risk: any [A,B,C] agent needs per-action human approval, and [A,B]/[A,C] configurations need an explicit residual-risk assessment — the Amazon Q incident (AWS-2025-019) wiped a developer's files from an [A,B] config. Endorsed by NIST AI 100-2 E2025 and the CISA/FBI/NSA/ACSC OT guidance (Dec 2025); the rule is silent on autonomy depth (Noma Security, 2025).
 
-**Addresses anatomy axes:** primarily (c) encoding; partial across (a).
-**Assumes:** the application controls the content pipeline; modality-specific classifiers exist and have been evaluated on adversarial examples.
-**Known limits:** semantic filters can be evaded by rephrasing or encoding; no filter set has demonstrated complete coverage as of Apr 2026; pixel-level adversarial perturbations bypass image safety classifiers not trained on adversarial examples.
+9. **Treat agent memory writes as privileged operations** — log the causing prompt, classify writes for instruction or role-modification content, and require approval before instruction-bearing memories persist across sessions. A Feb 2025 Gemini PoC (Embrace The Red) poisoned memory via delayed tool invocation (MITRE ATLAS AML.T0080.001). Factual entries shade into instructions, and incremental writes can evade per-write classification.
 
-#### 4. Grant the LLM only the minimum permissions it needs for each operation, and hold API credentials and state-change capabilities in application code, not in the model context
+10. **Pin, sign, and verify every MCP server and third-party tool package; audit tool descriptions for hidden instructions; monitor tool composition.** Treat these as a software supply-chain surface: the malicious postmark-mcp npm package (Koi Security, Sept 2025; corroborated by BleepingComputer) BCC'd email to an attacker for ~8 days across ~300 organizations. Pinning does not stop a payload shipped in the pinned version or tool-description poisoning that leaves the version unchanged.
 
-Provision the application layer — not the model — with API tokens, database write access, file-system permissions, and external communication channels. The model receives structured requests and returns structured responses; application code performs the privileged operation only after validating the response. Where possible, route privileged calls through a deterministic policy engine that re-validates intent and arguments at execution time, not only at agent startup.
-
-Treat this policy engine as a system-level requirement set at procurement and design-review time, not as a control to retrofit after deployment: both NIST AI 100-2 E2025 and the CISA + Five Eyes OT joint guidance (Dec 2025) frame deterministic mediation of model-driven actions as a baseline expectation for organizations deploying agents, which makes it a reasonable thing to require of vendors.
-
-**Addresses anatomy axes:** primarily (b) propagation; structural mitigation against (a) trusted-surface attacks.
-**Assumes:** the application can interpose between model output and privileged action; tool calls are auditable before execution.
-**Known limits:** broad permissions granted "for convenience" degrade this control; an injection that passes application-layer validation may still execute. Multi-agent pipelines can re-introduce the full property set at a downstream node, undoing the boundary established here. Procurement language is only as strong as the design-review process that enforces it — a contractual requirement with no verification step degrades to the same convenience-permission failure mode at deployment time.
-
-#### 5. Strip or reject Tag-block, variation-selector, and zero-width Unicode characters at every boundary where untrusted content enters the model context or where model output is rendered
-
-Apply Unicode normalization at each ingest point (API gateway, document parser, email, tool output) and at each render point (UI, downstream system, log). Remove or replace Tag-block (U+E0000–U+E007F), variation-selector (U+FE00–U+FE0F), and zero-width classes (U+200B/C/D, U+2060). These character classes are visually invisible in standard rendering and allow attackers to embed instructions or exfiltration-formatted bytes inside text that appears benign. The August 2024 PoC against M365 Copilot (Embrace The Red) demonstrated MFA-code exfiltration; subsequent variant-selector techniques (Embrace The Red, 2025) reduced cost to ~2 invisible characters per byte.
-
-**Addresses anatomy axes:** primarily (c) encoding — invisible-Unicode subclass.
-**Assumes:** normalization runs in trusted application code; the same scheme is applied at both ingest and render boundaries.
-**Known limits:** does not prevent injection through visible-text payloads; future steganographic categories outside the normalization list will evade until added; very aggressive normalization may break legitimate multilingual content.
-
-#### 6. Pass external content to the model through a structurally separate, explicitly labeled channel so the model can distinguish trusted instructions from untrusted data
-
-Mark each piece of content with its provenance before context assembly. Use structural separators — encoding schemes, prompt-level markers, or formatting the model has been trained to recognize as a trust signal — to reduce the probability that the model will treat externally sourced data as an instruction. Academic work on structured-channel separation (Chen et al., *StruQ*, USENIX Security 2025) and provenance marking at the prompt level (sometimes called "spotlighting" — Microsoft Research, 2025) reduce ASR substantially in non-adaptive evaluations, but adaptive bypass rates are materially higher.
-
-**Addresses anatomy axes:** primarily (a) delivery surface — explicitly marks each surface's trust level.
-**Assumes:** the application controls context assembly; the model is fine-tuned for or evaluated against the marking scheme in use.
-**Known limits:** an attacker who knows the marking scheme can mimic the marker format to "break out" of the data channel; multi-hop retrieval can introduce payloads after initial separation; StruQ and related defenses were bypassed under adaptive attack (Nasr/Carlini, 2025).
-
-#### 7. Require explicit, informed human confirmation before any privileged, irreversible, or externally visible action is taken
-
-Identify high-risk operations — sending email, executing code, deleting records, calling external APIs, writing to persistent storage — and route them through a confirmation step that surfaces the specific action verbatim to a human reviewer before execution. The reviewer must see the exact rendered text of what will be done, not a summary.
-
-**Addresses anatomy axes:** primarily (b) propagation — caps single-shot and multi-step kill-chain depth.
-**Assumes:** the confirmation interface strips or exposes invisible Unicode (Control 5); the reviewer has sufficient context to evaluate the action.
-**Known limits:** invisible-character smuggling can cause the displayed action to differ from the executed action (Embrace The Red, 2024); approval fatigue degrades reviewer judgment at high volume; multi-step "galaxy-brained" reasoning can produce plausible justifications for harmful actions.
-
-#### 8. Budget agent capabilities explicitly using the Rule of Two as a minimum baseline, and audit each [A,B], [A,C], and [B,C] configuration for residual risk
-
-Identify whether each agent simultaneously has access to (A) untrusted input, (B) sensitive systems / private data, and (C) state change / external comms. Any [A,B,C] configuration requires per-action human approval. For [A,B] and [A,C] configurations, perform an explicit residual-risk assessment: the Amazon Q July 2025 incident (AWS-2025-019) demonstrated an [A,B] configuration was exploited to wipe a developer's local file system and delete cloud resources when injected instructions bypassed Human-in-the-Loop confirmation. The underlying principle — minimize the privileged-action surface available to an LLM acting on untrusted input — is independently endorsed by NIST AI 100-2 E2025 (Mar 2025) and the CISA / FBI / NSA / ACSC + allied joint guidance on AI in operational technology (Dec 2025), which warn against process-model drift and unmediated agent control of safety-critical systems. Treat the Rule of Two as a floor, not a ceiling: layer least-privilege, tool-call allowlisting, and per-operation approval proportionate to damage potential.
-
-**Addresses anatomy axes:** primarily (b) propagation — caps multi-step kill-chain depth and lateral spread; secondary mitigation across (a).
-**Assumes:** agent capabilities and data access can be enumerated at design time; human-approval mechanisms exist for state-changing actions.
-**Known limits:** the rule is silent on agent autonomy depth (Noma Security critique, 2025); multi-agent pipelines can re-introduce the full property set downstream.
-
-#### 9. Treat agent memory writes as privileged operations: log the causing prompt, classify writes for instruction content, and require approval before instruction-containing memories persist across sessions
-
-When an agent maintains persistent memory (vector DB, key-value store, conversation history, hosted memory service), treat each write as a privileged action subject to the same controls as an external API call. Log the exact prompt and context that triggered each write. Apply a classifier to the content; if it contains instructions, directives, or role-modification language, route it to human or policy review before persisting. A Feb 2025 PoC against Gemini Advanced (Embrace The Red) demonstrated cross-session memory poisoning via delayed tool invocation; MITRE ATLAS classifies this as AML.T0080.001 (AI Agent Context Poisoning: Memory).
-
-**Addresses anatomy axes:** primarily (b) propagation — cross-session subclass; secondary on (a) memory delivery surface.
-**Assumes:** the application has a write hook / audit log; a classifier exists for distinguishing factual entries from behavioral instructions; memory writes are separable from reads architecturally.
-**Known limits:** factual memories shade into instructions; multi-step poisoning can evade per-write classification; many small writes can assemble a poisoned set incrementally.
-
-#### 10. Pin, sign, and verify every Model Context Protocol (MCP) server and third-party tool package your agents use; audit tool descriptions for hidden instructions; and monitor for changes in tool composition
-
-Treat MCP servers and third-party tool packages as a software supply-chain surface. Pin versions; verify package signatures or content hashes at install and at startup; audit tool descriptions and schema definitions for embedded instructions or unusual permission requests; monitor tool composition for unauthorized additions. The postmark-mcp incident (Koi Security, Sept 2025) — corroborated by BleepingComputer — demonstrated a malicious npm package silently BCC'd email content to an attacker for ~8 days, affecting an estimated 300 organizations. The GitHub MCP Server vulnerability (Invariant Labs, May 2025) and the Supabase MCP database-leak PoC (General Analysis, July 2025) demonstrated indirect prompt injection through trusted-but-attacker-influenced surfaces (a public GitHub issue; a customer-submitted support ticket) causing private-data exfiltration via agent tool calls.
-
-**Addresses anatomy axes:** primarily (a) MCP delivery surface; secondary on (b) propagation through trusted-surface chains.
-**Assumes:** the organization controls which MCP servers agents may connect to; verification runs before agent startup; tool descriptions are treated as untrusted.
-**Known limits:** version pinning does not protect against a payload introduced in a version already pinned; tool-description poisoning may not change the version number; baseline tool-composition enumeration must be actively maintained.
-
-#### 11. Test your defenses against adaptive attackers — assume the attacker has read the defense — and reject vendor or internal claims based only on static-attack evaluations
-
-Static test suites underestimate real-world ASR (Attack Success Rate) because they measure attackers who cannot adapt. For in-house evaluation, use structured agent-evaluation frameworks (AgentDojo, NeurIPS 2024: 97 tasks, 629 security test cases) and standardized adversarial-prompt benchmarks (JailbreakBench, NeurIPS 2024) as a baseline; augment with adaptive red-team exercises in which the testers receive the full defense specification and are allowed to optimize against it. For procurement and acceptance: require any defense's ASR to be measured the same way before relying on it. Nasr, Carlini et al. (Oct 2025) showed that for most of 12 recent defenses, static ASR was near zero while adaptive ASR exceeded 90%. The LLMail-Inject challenge (Microsoft MSRC / SaTML 2025) is one example of partially-competitive adaptive evaluation in practice.
-
-**Addresses anatomy axes:** evaluation coverage across all three (a/b/c).
-**Assumes:** the testing team has white-box or gray-box access to the defense; evaluation is repeated after every significant change to model, prompt, classifier rules, or tool configuration; procurement decisions weigh adaptive-attack ASR rather than vendor-supplied static figures.
-**Known limits:** adaptive testing is bounded by the testers' compute and creativity; results from one model or version may not transfer; adaptive evaluation does not scale to high-frequency deployment changes; the procurement gate depends on a vendor's willingness to expose enough of the defense for meaningful adaptive testing.
+11. **Test against adaptive attackers who have read your defense; reject static-only ASR claims.** Baseline with AgentDojo (NeurIPS 2024) and JailbreakBench (NeurIPS 2024), then red-team with the full defense specification disclosed to the testers. Nasr, Carlini et al. (Oct 2025) found static ASR near zero while adaptive ASR exceeded 90% for most of 12 recent defenses (see also LLMail-Inject, Microsoft MSRC / SaTML 2025).
 
 ---
 
 ### Example Attack Scenarios
 
-**Scenario #1: Direct Injection.** An attacker injects a prompt into a customer-support chatbot, instructing it to ignore previous guidelines, query private data stores, and send emails — leading to unauthorized access and privilege escalation.
-
+**Scenario #1: Direct Injection.** An attacker prompts a customer-support chatbot to ignore its guidelines, query private data stores, and send emails — leading to unauthorized access and privilege escalation.
 **Anatomy:** (a) direct user input · (b) single-shot · (c) plain text
 
----
-
-**Scenario #2: Indirect Injection via Retrieved Web Content.** A user asks an LLM-powered assistant to summarize a webpage that contains hidden instructions. The model follows the instructions and inserts a markdown image whose URL exfiltrates the user's private conversation context to an attacker-controlled domain. The user never sees the instruction; they may see the rendered image.
-
+**Scenario #2: Indirect Injection via Retrieved Web Content.** A user asks an assistant to summarize a web page containing hidden instructions; the model inserts a markdown image whose URL exfiltrates the private conversation to an attacker-controlled domain. The user sees only the rendered image, never the instruction.
 **Anatomy:** (a) retrieved web content (indirect) · (b) single-shot with image-URL exfiltration · (c) plain text (hidden in page source)
 
----
-
-**Scenario #3: Unintentional Injection.** A company embeds an AI-detection instruction in a job-description PDF. An applicant, unaware of the instruction, uses an LLM to optimize their resume against the JD. The model surfaces the AI-detection instruction during evaluation and the recruiting system flags the candidate. This is a prompt injection caused by neither party acting maliciously.
-
+**Scenario #3: Unintentional Injection.** A job-description PDF embeds an AI-detection instruction. An applicant unknowingly uses an LLM to optimize their resume against it; the model surfaces the instruction and the recruiting system flags the candidate — a prompt injection with neither party acting maliciously.
 **Anatomy:** (a) indirect (document / PDF) · (b) single-shot · (c) plain text
 
----
-
-**Scenario #4: RAG Repository Poisoning.** An attacker contributes documents to a corpus the application retrieves over. When a user's query returns the modified content, the malicious instructions alter the LLM's output. As few as five injected documents have been shown to achieve attack-success rates above 95% on standard question-answering corpora (PoisonedRAG, USENIX Security 2025).
-
+**Scenario #4: RAG Repository Poisoning.** An attacker contributes poisoned documents to a corpus the application retrieves over; a matching query returns the modified content and its instructions alter the output. As few as five injected documents have achieved attack-success rates above 95% on standard question-answering corpora (PoisonedRAG, USENIX Security 2025).
 **Anatomy:** (a) retrieved content (RAG corpus) · (b) cross-session / cross-user · (c) plain text
 
----
-
-**Scenario #5: Payload Splitting.** An attacker submits a resume with malicious instructions split across multiple input fields (header, body, attachment) such that no individual field looks malicious to a single-field classifier. When the LLM evaluates the candidate, the recombined instructions manipulate the model's recommendation.
-
+**Scenario #5: Payload Splitting.** An attacker splits malicious instructions across multiple resume fields (header, body, attachment) so no single field looks malicious to a per-field classifier; the LLM recombines them at evaluation and its recommendation is manipulated.
 **Anatomy:** (a) direct user input (split across fields) · (b) single-shot (recombined at eval) · (c) plain text (fragmented)
 
----
-
-**Scenario #6: Multimodal Steganographic Injection.** An attacker embeds a malicious instruction within an image at the pixel level, below human visual threshold. When a multimodal LLM processes the image alongside benign text, the vision encoder extracts the payload and the model's behavior changes — leading to harmful output or unauthorized tool invocation. This class has been demonstrated against four frontier vision-language models in a domain-specific (oncology) deployment (Clusmann et al., *Nature Communications*, 2024) and against general-purpose multimodal models via combined visual perturbation and text steering (JPS, ACM MM 2025).
-
+**Scenario #6: Multimodal Steganographic Injection.** An attacker embeds an instruction in an image below the human visual threshold; a multimodal model's vision encoder extracts the payload and behavior changes, producing harmful output or unauthorized tool invocation. Demonstrated against four frontier vision-language models in oncology imaging (Clusmann et al., *Nature Communications*, 2024) and against general-purpose models via combined visual perturbation and text steering (JPS, ACM MM 2025).
 **Anatomy:** (a) image input (indirect / multimodal) · (b) single-shot · (c) steganographic / pixel-level encoding
 
----
-
-**Scenario #7: Zero-Click Document-Borne Agentic Exfiltration.** A crafted email triggers an LLM-powered productivity assistant to exfiltrate organizational data without user interaction. Aim Security researchers demonstrated this class against Microsoft 365 Copilot (CVE-2025-32711, "EchoLeak", patched June 2025), bypassing both the deployed prompt-injection classifier and the link-redaction filter.
-
+**Scenario #7: Zero-Click Document-Borne Agentic Exfiltration.** A crafted email triggers an LLM-powered productivity assistant to exfiltrate organizational data with no user interaction. Aim Security demonstrated this against Microsoft 365 Copilot (CVE-2025-32711, "EchoLeak", patched June 2025), bypassing both the deployed prompt-injection classifier and the link-redaction filter.
 **Anatomy:** (a) email / document (indirect) · (b) single-shot with tool invocation · (c) plain text with invisible-Unicode exfiltration channel
 
----
-
-**Scenario #8: Agentic Destructive Command Execution.** Two events from July 2025 illustrate the same impact through different attack vectors. In one, an attacker compromised access to the Amazon Q VS Code extension repository and committed a system prompt instructing deletion of home directories and AWS resources; the malicious version reached approximately one million installs before reversion (AWS-2025-015). In the other, a separately demonstrated runtime injection caused Amazon Q to execute arbitrary code through prompt injection alone (AWS-2025-019). Both surface the same risk: an agent with shell, file-system, or cloud-API access amplifies an injection into a host-impacting incident.
-
+**Scenario #8: Agentic Destructive Command Execution.** Two July 2025 events show the same impact via different vectors: an attacker committed a destructive system prompt to the Amazon Q VS Code extension repository, reaching ~1 million installs before reversion (AWS-2025-015); separately, a runtime injection caused Amazon Q to execute arbitrary code (AWS-2025-019). An agent with shell, file-system, or cloud-API access amplifies an injection into a host-impacting incident.
 **Anatomy:** (a) supply-chain / compromised system prompt (AWS-2025-015) or runtime indirect injection (AWS-2025-019) · (b) persistent cross-session (supply-chain) / single-shot with shell tool execution (runtime) · (c) plain text
 
----
-
-**Scenario #9: Trusted-Backend Indirect Injection through MCP.** An attacker submits crafted text into a low-privilege channel — a public GitHub issue, a customer support ticket, or a malicious npm package the developer installs — and the developer's LLM reads it while operating under elevated credentials. In May 2025, Invariant Labs showed that a malicious GitHub issue caused an MCP-connected coding assistant to exfiltrate private repository contents. In July 2025, General Analysis showed that a customer support ticket caused Cursor's Supabase MCP server (running with `service_role` privileges that bypass row-level security) to dump the production database into the user-visible support thread. In September 2025, a malicious `postmark-mcp` npm package silently BCC'd email content to an attacker for approximately eight days before discovery.
-
+**Scenario #9: Trusted-Backend Indirect Injection through MCP.** An attacker plants text in a low-privilege channel — a public GitHub issue, a support ticket, or a malicious npm package — and the developer's LLM reads it under elevated credentials. Invariant Labs (May 2025) exfiltrated private repositories via a poisoned GitHub issue; General Analysis (July 2025) dumped a production database through Cursor's Supabase MCP server (running `service_role`, bypassing row-level security); the malicious `postmark-mcp` package (Sept 2025) BCC'd email to an attacker for ~8 days.
 **Anatomy:** (a) trusted-surface indirect (MCP channel — issue, ticket, npm package) · (b) multi-step tool-chain · (c) plain text
 
 ### Reference Links
@@ -226,75 +131,76 @@ Static test suites underestimate real-world ASR (Attack Success Rate) because th
 2. [Inject My PDF: Prompt Injection for your Resume](https://kai-greshake.de/posts/inject-my-pdf): **Kai Greshake**, 2023
 3. [Universal and Transferable Adversarial Attacks on Aligned Language Models](https://arxiv.org/abs/2307.15043): Zou et al., **arXiv** 2023
 4. [Adversarial Machine Learning: A Taxonomy and Terminology of Attacks and Mitigations (NIST AI 100-2 E2025)](https://csrc.nist.gov/pubs/ai/100/2/e2025/final): **NIST**, March 2025
-5. [Generative AI Profile (NIST AI 600-1)](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf): **NIST**, July 2024
-6. [Prompt injection is not SQL injection](https://www.ncsc.gov.uk/blog-post/prompt-injection-is-not-sql-injection): **UK NCSC**, December 2025
-7. [Principles for the Secure Integration of AI in Operational Technology](https://www.cisa.gov/sites/default/files/2025-12/joint-guidance-principles-for-the-secure-integration-of-artificial-intelligence-in-operational-technology-508c.pdf): **CISA + FBI + NSA + ACSC + allied partners**, December 2025
-8. [The Attacker Moves Second: Stronger Adaptive Attacks Bypass Defenses Against LLM Jailbreaks and Prompt Injections](https://arxiv.org/abs/2510.09023): Nasr, Carlini et al., **arXiv** 2510.09023, October 2025
-9. [Prompt injection attacks on vision language models in oncology](https://www.nature.com/articles/s41467-024-55631-x): Clusmann et al., ***Nature Communications***, 2024
-10. [JPS: Jailbreak Multimodal LLMs with Collaborative Visual Perturbation and Textual Steering](https://dl.acm.org/doi/10.1145/3746027.3754561): Wang et al., **ACM MM 2025**
-11. [Bypassing Prompt Injection Guardrails via Code-Switching and Unicode Transcoding](https://arxiv.org/html/2504.11168v2): **arXiv**:2504.11168, 2025
-12. [PoisonedRAG: Knowledge Corruption Attacks to Retrieval-Augmented Generation](https://www.usenix.org/system/files/usenixsecurity25-zou-poisonedrag.pdf): Zou et al., **USENIX Security 2025**
-13. [StruQ: Defending Against Prompt Injection with Structured Queries](https://www.usenix.org/system/files/usenixsecurity25-chen-sizhe.pdf): Chen et al., **USENIX Security 2025**
-14. [Fun-tuning: Characterizing the Vulnerability of Proprietary LLMs to Optimization-based Prompt Injection Attacks via the Fine-Tuning Interface](https://arxiv.org/abs/2501.09798): Labunets et al., **arXiv** 2501.09798, January 2025
-15. [Model Context Protocol (MCP): Landscape, Security Threats, and Future Research Directions](https://dl.acm.org/doi/10.1145/3796519): Hou et al., **ACM TOSEM 2025**
-16. [AgentDojo: A Dynamic Environment to Evaluate Prompt Injection Attacks and Defenses for LLM Agents](https://arxiv.org/abs/2406.13352): Debenedetti et al., **NeurIPS 2024**
-17. [JailbreakBench: An Open Robustness Benchmark for Jailbreaking Large Language Models](https://arxiv.org/abs/2404.01318): Chao et al., **NeurIPS 2024**
-18. [M365 Copilot Prompt Injection, Tool Invocation and Data Exfil using ASCII Smuggling](https://embracethered.com/blog/posts/2024/m365-copilot-prompt-injection-tool-invocation-and-data-exfil-using-ascii-smuggling/): Johann Rehberger (**Embrace The Red**), August 2024
-19. [Sneaky Bits & ASCII Smuggler updates](https://embracethered.com/blog/posts/2025/sneaky-bits-and-ascii-smuggler/): Johann Rehberger (**Embrace The Red**), 2025
-20. [Hacking Gemini's Memory with Prompt Injection and Delayed Tool Invocation](https://embracethered.com/blog/posts/2025/google-gemini-memory-persistence-prompt-injection/): Johann Rehberger, February 2025
-21. [GitHub Copilot Remote Code Execution via Prompt Injection (CVE-2025-53773)](https://embracethered.com/blog/posts/2025/github-copilot-remote-code-execution-via-prompt-injection/): Johann Rehberger, 2025
-22. [Promptfoo ASCII-smuggling red-team plugin docs](https://www.promptfoo.dev/docs/red-team/plugins/ascii-smuggling/): **Promptfoo**
-23. [GitHub MCP Server Vulnerability](https://invariantlabs.ai/blog/mcp-github-vulnerability): **Invariant Labs**, May 2025
-24. [Supabase MCP can leak your entire SQL database](https://generalanalysis.com/blog/supabase-mcp-blog): **General Analysis**, July 2025
-25. [Postmark-MCP npm Malicious Backdoor — Email Theft](https://www.koi.ai/blog/postmark-mcp-npm-malicious-backdoor-email-theft): **Koi Security**, September 2025
-26. [Unofficial Postmark MCP npm package silently stole users' emails](https://www.bleepingcomputer.com/news/security/unofficial-postmark-mcp-npm-silently-stole-users-emails/): **BleepingComputer**, September 2025
-27. [Defending Against Indirect Prompt Injection Attacks With Spotlighting](https://www.microsoft.com/en-us/research/publication/defending-against-indirect-prompt-injection-attacks-with-spotlighting/): **Microsoft Research**, 2025
-28. [Announcing the Winners of the Adaptive Prompt Injection Challenge — LLMail-Inject](https://www.microsoft.com/en-us/msrc/blog/2025/03/announcing-the-winners-of-the-adaptive-prompt-injection-challenge-llmail-inject/): **Microsoft MSRC**, March 2025
-29. [Practical AI Agent Security: Agents Rule of Two](https://ai.meta.com/blog/practical-ai-agent-security/): **Meta AI**, October 2025
-30. [Why the Rule of Two Can't Protect Your Agents](https://noma.security/blog/mcp-servers-agentic-risk-and-the-framework-that-protects-it/): **Noma Security**, 2025
-31. [AWS-2025-015 (Amazon Q VS Code extension supply-chain incident)](https://aws.amazon.com/security/security-bulletins/AWS-2025-015/): **AWS Security Bulletin**, July 2025
-32. [AWS-2025-019 (Amazon Q runtime injection)](https://aws.amazon.com/security/security-bulletins/AWS-2025-019/): **AWS Security Bulletin**, July 2025
-33. [EchoLeak (CVE-2025-32711) — Microsoft 365 Copilot zero-click prompt injection](https://arxiv.org/abs/2509.10540): Reddy and Gujral, **Aim Security, AAAI Fall Symposium 2025**; paired with [NVD entry](https://nvd.nist.gov/vuln/detail/CVE-2025-32711)
-34. [CVE-2024-5184 (EmailGPT) advisory](https://www.incibe.es/en/incibe-cert/early-warning/vulnerabilities/cve-2024-5184): **INCIBE-CERT**, 2024
-35. [Anthropic, Google, Microsoft paid AI bug bounties – quietly](https://www.theregister.com/2026/04/15/claude_gemini_copilot_agents_hijacked/): **The Register**
-36. [CamoLeak: Critical GitHub Copilot vulnerability leaks private source code](https://www.legitsecurity.com/blog/camoleak-critical-github-copilot-vulnerability-leaks-private-source-code): **Legit Security**
-37. [How Microsoft defends against indirect prompt injection attacks](https://www.microsoft.com/en-us/msrc/blog/2025/07/how-microsoft-defends-against-indirect-prompt-injection-attacks): **Microsoft MSRC**
-38. [Attacking and Defending Generative AI](https://github.com/NetsecExplained/Attacking-and-Defending-Generative-AI): **NetsecExplained**
-39. [Arcanum Prompt Injection Taxonomy](https://arcanum-sec.github.io/arc_pi_taxonomy): **Arcanum Sec**
-40. [Pangea Prompt Injection Taxonomy](https://pangea.cloud/taxonomy/): **Pangea (CrowdStrike)**
-41. [The Terminology Problem Causing Security Teams Real Risks](https://www.pillar.security/blog/the-terminology-problem-causing-security-teams-real-risks): **Pillar Security**
-42. [Prompt Injection Isn't a Vulnerability](https://josephthacker.com/ai/2025/11/24/prompt-injection-isnt-a-vulnerability.html): **Joseph Thacker**
-43. [Defeating Prompt Injections by Design (CaMeL)](https://arxiv.org/abs/2503.18813): Debenedetti et al., **arXiv** 2503.18813, 2025
-44. [The lethal trifecta for AI agents: private data, untrusted content, and external communication](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/): **Simon Willison**, June 2025
-45. [OWASP Top 10 for LLM Applications — LLM01:2025 Prompt Injection](https://genai.owasp.org/llmrisk/llm01-prompt-injection/): **OWASP GenAI Security Project**, 2025
+5. [Prompt injection is not SQL injection](https://www.ncsc.gov.uk/blog-post/prompt-injection-is-not-sql-injection): **UK NCSC**, December 2025
+6. [Principles for the Secure Integration of AI in Operational Technology](https://www.cisa.gov/sites/default/files/2025-12/joint-guidance-principles-for-the-secure-integration-of-artificial-intelligence-in-operational-technology-508c.pdf): **CISA + FBI + NSA + ACSC + allied partners**, December 2025
+7. [The Attacker Moves Second: Stronger Adaptive Attacks Bypass Defenses Against LLM Jailbreaks and Prompt Injections](https://arxiv.org/abs/2510.09023): Nasr, Carlini et al., **arXiv** 2510.09023, October 2025
+8. [Prompt injection attacks on vision language models in oncology](https://www.nature.com/articles/s41467-024-55631-x): Clusmann et al., ***Nature Communications***, 2024
+9. [JPS: Jailbreak Multimodal LLMs with Collaborative Visual Perturbation and Textual Steering](https://dl.acm.org/doi/10.1145/3746027.3754561): Wang et al., **ACM MM 2025**
+10. [Bypassing Prompt Injection Guardrails via Code-Switching and Unicode Transcoding](https://arxiv.org/html/2504.11168v2): **arXiv**:2504.11168, 2025
+11. [PoisonedRAG: Knowledge Corruption Attacks to Retrieval-Augmented Generation](https://www.usenix.org/system/files/usenixsecurity25-zou-poisonedrag.pdf): Zou et al., **USENIX Security 2025**
+12. [StruQ: Defending Against Prompt Injection with Structured Queries](https://www.usenix.org/system/files/usenixsecurity25-chen-sizhe.pdf): Chen et al., **USENIX Security 2025**
+13. [Fun-tuning: Characterizing the Vulnerability of Proprietary LLMs to Optimization-based Prompt Injection Attacks via the Fine-Tuning Interface](https://arxiv.org/abs/2501.09798): Labunets et al., **arXiv** 2501.09798, January 2025
+14. [AgentDojo: A Dynamic Environment to Evaluate Prompt Injection Attacks and Defenses for LLM Agents](https://arxiv.org/abs/2406.13352): Debenedetti et al., **NeurIPS 2024**
+15. [JailbreakBench: An Open Robustness Benchmark for Jailbreaking Large Language Models](https://arxiv.org/abs/2404.01318): Chao et al., **NeurIPS 2024**
+16. [M365 Copilot Prompt Injection, Tool Invocation and Data Exfil using ASCII Smuggling](https://embracethered.com/blog/posts/2024/m365-copilot-prompt-injection-tool-invocation-and-data-exfil-using-ascii-smuggling/): Johann Rehberger (**Embrace The Red**), August 2024
+17. [Sneaky Bits & ASCII Smuggler updates](https://embracethered.com/blog/posts/2025/sneaky-bits-and-ascii-smuggler/): Johann Rehberger (**Embrace The Red**), 2025
+18. [Hacking Gemini's Memory with Prompt Injection and Delayed Tool Invocation](https://embracethered.com/blog/posts/2025/google-gemini-memory-persistence-prompt-injection/): Johann Rehberger, February 2025
+19. [GitHub Copilot Remote Code Execution via Prompt Injection (CVE-2025-53773)](https://embracethered.com/blog/posts/2025/github-copilot-remote-code-execution-via-prompt-injection/): Johann Rehberger, 2025
+20. [GitHub MCP Server Vulnerability](https://invariantlabs.ai/blog/mcp-github-vulnerability): **Invariant Labs**, May 2025
+21. [Supabase MCP can leak your entire SQL database](https://generalanalysis.com/blog/supabase-mcp-blog): **General Analysis**, July 2025
+22. [Postmark-MCP npm Malicious Backdoor — Email Theft](https://www.koi.ai/blog/postmark-mcp-npm-malicious-backdoor-email-theft): **Koi Security**, September 2025
+23. [Unofficial Postmark MCP npm package silently stole users' emails](https://www.bleepingcomputer.com/news/security/unofficial-postmark-mcp-npm-silently-stole-users-emails/): **BleepingComputer**, September 2025
+24. [Defending Against Indirect Prompt Injection Attacks With Spotlighting](https://www.microsoft.com/en-us/research/publication/defending-against-indirect-prompt-injection-attacks-with-spotlighting/): **Microsoft Research**, 2025
+25. [Announcing the Winners of the Adaptive Prompt Injection Challenge — LLMail-Inject](https://www.microsoft.com/en-us/msrc/blog/2025/03/announcing-the-winners-of-the-adaptive-prompt-injection-challenge-llmail-inject/): **Microsoft MSRC**, March 2025
+26. [Practical AI Agent Security: Agents Rule of Two](https://ai.meta.com/blog/practical-ai-agent-security/): **Meta AI**, October 2025
+27. [Why the Rule of Two Can't Protect Your Agents](https://noma.security/blog/mcp-servers-agentic-risk-and-the-framework-that-protects-it/): **Noma Security**, 2025
+28. [AWS-2025-015 (Amazon Q VS Code extension supply-chain incident)](https://aws.amazon.com/security/security-bulletins/AWS-2025-015/): **AWS Security Bulletin**, July 2025
+29. [AWS-2025-019 (Amazon Q runtime injection)](https://aws.amazon.com/security/security-bulletins/AWS-2025-019/): **AWS Security Bulletin**, July 2025
+30. [EchoLeak (CVE-2025-32711) — Microsoft 365 Copilot zero-click prompt injection](https://arxiv.org/abs/2509.10540): Reddy and Gujral, **Aim Security, AAAI Fall Symposium 2025**; paired with [NVD entry](https://nvd.nist.gov/vuln/detail/CVE-2025-32711)
+31. [CVE-2024-5184 (EmailGPT) advisory](https://www.incibe.es/en/incibe-cert/early-warning/vulnerabilities/cve-2024-5184): **INCIBE-CERT**, 2024
+32. [Defeating Prompt Injections by Design (CaMeL)](https://arxiv.org/abs/2503.18813): Debenedetti et al., **arXiv** 2503.18813, 2025
+33. [The lethal trifecta for AI agents: private data, untrusted content, and external communication](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/): **Simon Willison**, June 2025
+34. [OWASP Top 10 for LLM Applications — LLM01:2025 Prompt Injection](https://genai.owasp.org/llmrisk/llm01-prompt-injection/): **OWASP GenAI Security Project**, 2025
 
 ---
 ### Related Frameworks and Taxonomies
 
-| Framework | Reference | Relevance |
-|---|---|---|
-| **OWASP Top 10 for Agentic Applications (ASI)** | ASI01 — Agent Goal Hijack | Injected input overrides the system prompt's role and capability constraints, redirecting agent goals (Common Examples #1; Scenario #1) |
-| **OWASP Top 10 for Agentic Applications (ASI)** | ASI02 — Tool Misuse & Exploitation | Injected input drives unauthorized tool invocation; Simon Willison's "lethal trifecta" (private data access, untrusted content, external communication) is cited as the structural diagnosis for when this becomes exploitable (Prevention intro, ¶2; Common Examples #3; Scenario #9) |
-| **OWASP Top 10 for Agentic Applications (ASI)** | ASI03 — Identity & Privilege Abuse | Trusted-surface indirect injection causes the agent to act "under the user's elevated credentials," performing privileged actions the attacker could not perform directly (Indirect Prompt Injection section; Scenario #9) |
-| **OWASP Top 10 for Agentic Applications (ASI)** | ASI05 — Unexpected Code Execution (RCE) | Agent shell, file-system, or cloud-API access turns a successful injection into arbitrary command execution (Description outcomes list, "Where the agent has shell, file-system, or cloud-API access"; Scenario #8, CVE-2025-53773) |
-| **OWASP Top 10 for Agentic Applications (ASI)** | ASI06 — Memory & Context Poisoning | Cross-session memory and RAG corpus poisoning taint every future session reading from the compromised store (Common Examples #6; Control #9, citing MITRE ATLAS AML.T0080.001) |
-| **OWASP Top 10 for Agentic Applications (ASI)** | ASI08 — Cascading Failures | Tool outputs re-enter the context window, enabling chained or self-replicating effects across a multi-step tool chain (Description ¶2; Scenario #9) |
-| **OWASP Top 10 for Agentic Applications (ASI)** | ASI09 — Human-Agent Trust Exploitation | Injected instructions bypass Human-in-the-Loop confirmation, exploiting the trust placed in the confirmation step itself (Control #7; Scenario #8, AWS-2025-019) |
-| **MITRE ATLAS** | AML.T0051.000 — LLM Prompt Injection: Direct | Direct-injection technique underlying the Direct Prompt Injection section and Scenario #1 |
-| **MITRE ATLAS** | AML.T0051.001 — LLM Prompt Injection: Indirect | Indirect-injection technique underlying the Indirect Prompt Injection section and Scenarios #2, #4, #7, #9 |
-| **MITRE ATLAS** | AML.T0054 — LLM Jailbreak Injection: Direct | Jailbreak subset of direct injection discussed in the Direct Prompt Injection section |
-| **MITRE ATLAS** | AML.T0057 — LLM Data Leakage | Disclosure outcome of a successful injection (Common Examples #1) |
-| **MITRE ATLAS** | AML.T0065 — LLM Prompt Crafting | Adversarial payload construction, including the fine-tuning-API gradient-oracle ("fun-tuning") technique (Common Examples #7) |
-| **MITRE ATLAS** | AML.T0068 — LLM Prompt Obfuscation | Invisible-Unicode and multilingual/encoded payload techniques (Common Examples #5, #8) |
-| **MITRE ATLAS** | AML.T0070 — RAG Poisoning | RAG corpus poisoning technique (Common Examples #6; Scenario #4, PoisonedRAG) |
-| **MITRE ATLAS** | AML.T0080.001 — AI Agent Context Poisoning: Memory | Cross-session memory poisoning technique, cited directly in Control #9 against the Gemini memory-persistence PoC |
-| **MITRE ATLAS** | AML.T0099 — AI Agent Tool Data Poisoning | An attacker plants poisoned content in a low-privilege channel for an MCP-connected tool to retrieve, and the agent acts on it under elevated credentials (Common Examples #3; Scenario #9, GitHub MCP / Supabase MCP / postmark-mcp) |
-| **MITRE ATLAS** | AML.T0086 — Exfiltration via AI Agent Tool Invocation | Tool-call-mediated exfiltration (Scenario #9: GitHub MCP, Supabase MCP, postmark-mcp) |
-| **MITRE ATLAS** | AML.T0102 — Generate Malicious Commands | Attacker-directed generation of destructive commands (Scenario #8, Amazon Q) |
-| **MITRE ATLAS** | AML.T0105 — Escape to Host | Host-level command execution and destructive action via agent shell/cloud-API access (Description outcomes list, "Where the agent has shell, file-system, or cloud-API access"; Scenario #8) |
-| **MITRE ATLAS** | AML.T0110 — AI Agent Tool Poisoning | Poisoned MCP server descriptions or tool definitions that trick the model into unauthorized actions (Control #10) |
-| **MITRE ATT&CK** | T1195 — Supply Chain Compromise | Compromised MCP server / npm package as an injection delivery surface (Control #10; Scenario #8, AWS-2025-015; Scenario #9, postmark-mcp) |
-| **NIST AI 100-2 E2025** | Adversarial Machine Learning: A Taxonomy and Terminology of Attacks and Mitigations | Cited as the baseline position that no robust prevention mechanism exists because LLMs make no architectural distinction between instructions and data (Prevention intro; Control #4, #8) |
-| **OWASP AIVSS** | AI Vulnerability Scoring System | Severity-scoring framework applicable to prompt-injection findings |
-| **OWASP GenAI Data Security 2026 (v1.0)** | DSGAI01 — Sensitive Data Leakage | DSGAI01's mitigations name indirect-prompt-injection exfiltration (markdown-image rendering, tool-callback allowlisting) as an explicit control category, and both entries independently cite CVE-2024-5184 (EmailGPT) |
-| **OWASP GenAI Data Security 2026 (v1.0)** | DSGAI06 — Tool, Plugin & Agent Data Exchange Risks | DSGAI06's "tool poisoning via crafted metadata" vector — malicious MCP server descriptions or plugin manifests that "exploit the model's tendency to treat tool descriptions as trusted instructions" — is the same mechanism as this entry's Control #10, and both entries cite the postmark-mcp incident |
+**OWASP Top 10 for Agentic Applications (ASI)**
+
+| ID | Relevance |
+|---|---|
+| ASI01 — Agent Goal Hijack | Injected input overrides the system-prompt role/capability constraints, redirecting agent goals. |
+| ASI02 — Tool Misuse & Exploitation | Injected input drives unauthorized tool invocation (the "lethal trifecta" conditions). |
+| ASI03 — Identity & Privilege Abuse | Agent acts under the user's elevated credentials, performing actions the attacker could not. |
+| ASI05 — Unexpected Code Execution (RCE) | Shell / file-system / cloud-API access turns injection into arbitrary command execution. |
+| ASI06 — Memory & Context Poisoning | Memory and RAG poisoning taint every future session reading the store. |
+| ASI08 — Cascading Failures | Tool outputs re-enter the context window, enabling chained or self-replicating effects. |
+| ASI09 — Human-Agent Trust Exploitation | Injection bypasses human-in-the-loop confirmation. |
+
+**MITRE ATLAS**
+
+| ID | Relevance |
+|---|---|
+| AML.T0051.000 — LLM Prompt Injection: Direct | Direct-injection technique (Direct Prompt Injection; Scenario #1). |
+| AML.T0051.001 — LLM Prompt Injection: Indirect | Indirect-injection technique (Scenarios #2, #4, #7, #9). |
+| AML.T0054 — LLM Jailbreak Injection: Direct | Jailbreak subset of direct injection. |
+| AML.T0057 — LLM Data Leakage | Disclosure outcome of a successful injection. |
+| AML.T0065 — LLM Prompt Crafting | Adversarial payload construction, incl. the "fun-tuning" gradient-oracle technique. |
+| AML.T0068 — LLM Prompt Obfuscation | Invisible-Unicode and multilingual/encoded payloads. |
+| AML.T0070 — RAG Poisoning | RAG corpus poisoning (Scenario #4). |
+| AML.T0080.001 — AI Agent Context Poisoning: Memory | Cross-session memory poisoning (Control #9). |
+| AML.T0099 — AI Agent Tool Data Poisoning | Poisoned content retrieved by an MCP-connected tool, acted on under elevated credentials. |
+| AML.T0086 — Exfiltration via AI Agent Tool Invocation | Tool-call-mediated exfiltration (Scenario #9). |
+| AML.T0102 — Generate Malicious Commands | Attacker-directed generation of destructive commands (Scenario #8). |
+| AML.T0105 — Escape to Host | Host-level execution via agent shell / cloud-API access. |
+| AML.T0110 — AI Agent Tool Poisoning | Poisoned MCP server descriptions or tool definitions (Control #10). |
+
+**Other frameworks**
+
+| Framework / ID | Relevance |
+|---|---|
+| MITRE ATT&CK T1195 — Supply Chain Compromise | Compromised MCP server / npm package as a delivery surface (Control #10; Scenarios #8–#9). |
+| NIST AI 100-2 E2025 | Baseline position that no robust prevention exists because LLMs do not separate instructions from data. |
+| OWASP AIVSS | AI Vulnerability Scoring System — severity scoring applicable to prompt-injection findings. |
+| OWASP GenAI Data Security 2026 — DSGAI01 (Sensitive Data Leakage) | Names indirect-PI exfiltration (markdown-image, tool-callback allowlisting) as a control category; both entries cite CVE-2024-5184. |
+| OWASP GenAI Data Security 2026 — DSGAI06 (Tool, Plugin & Agent Data Exchange) | "Tool poisoning via crafted metadata" is the same mechanism as Control #10; both entries cite the postmark-mcp incident. |

--- a/2026/final/LLM01_PromptInjection.md
+++ b/2026/final/LLM01_PromptInjection.md
@@ -8,8 +8,6 @@ Prompt injection vulnerabilities exist in how models process input and how that 
 
 A given prompt injection anatomy can be characterized along three axes: **Delivery surface** or how it reaches the model (direct input, retrieved content, tool output, tool connection channel, persistent memory, or, indirectly, a fine-tuning interface used to craft the payload); **propagation behavior** or how it spreads across time and boundaries (single-shot, multi-step kill-chain, cross-session through memory or RAG, or self-replicating across agents); and **encoding** or how the malicious instructions are represented in tokens or pixels (plain text, base64 or other obfuscation, invisible Unicode, multimodal or steganographic, low-resource language). Decomposing a scenario along these axes is a useful threat-modeling step before selecting which mitigations apply.
 
-A single attack typically combines one item from each axis. *Example:* the August 2024 M365 Copilot ASCII-smuggling PoC (Embrace The Red) was (a) document-file delivery, (b) single-shot in the targeted session but multi-step in its tool-invocation chain, (c) Tag-block invisible Unicode encoding. Decomposing each scenario along these axes is the first step of any threat model and the framework against which each control below is evaluated.
-
 The severity and nature of a successful prompt injection vary with the business context the model operates in and the agency with which it is architected. Generally, prompt injection can lead to outcomes that include but are not limited to:
 
 * Disclosure of sensitive information, system-prompt content, retrieved private documents, or infrastructure details.
@@ -46,21 +44,21 @@ Indirect prompt injection is increasingly used to turn the user's own LLM instan
 
 ### Common Examples of Risk
 
-1. **Direct prompt-input override.** A user-supplied message bypasses the system prompt's role and capability constraints, causing the model to disclose, generate, or act outside its intended scope. The input can be intentional or unintentional; both should be handled.
+1. **Direct prompt-input override** — a user message overrides the system prompt's role and capability limits, making the model disclose, generate, or act outside its intended scope; intentional and unintentional inputs both count.
 
-2. **Indirect injection through retrieved content.** A RAG passage, retrieved web page, document, or email contains attacker-supplied instructions that the model follows when the content reaches the context window. CVE-2024-5184 (EmailGPT, 2024) is an example against a deployed Gmail extension.
+2. **Indirect injection through retrieved content** — attacker instructions ride in a RAG passage, web page, document, or email and run when the content reaches the context window (e.g., CVE-2024-5184, EmailGPT).
 
-3. **Trusted-surface indirect injection.** An attacker submits text through a low-privilege channel (issue tracker, feedback form, support ticket) into a location the user's LLM treats as trusted; the LLM then performs privileged actions under the user's credentials — exfiltrating repositories, dumping databases, or modifying IDE configuration — that the attacker could not perform directly (GitHub MCP, Supabase MCP, CVE-2025-53773).
+3. **Trusted-surface indirect injection** — text planted in a low-privilege but trusted channel (issue tracker, feedback form, support ticket) makes the user's LLM act under its own elevated credentials — exfiltrating repositories, dumping databases, or modifying IDE config — that the attacker could not do directly (GitHub MCP, Supabase MCP, CVE-2025-53773).
 
-4. **Multimodal and steganographic injection.** Adversarial perturbations invisible to humans are embedded in images, audio, or video frames; vision and audio encoders extract the payload. All four frontier vision-language models tested in a 2024 oncology-imaging study (Clusmann et al., *Nature Communications*) were susceptible.
+4. **Multimodal and steganographic injection** — sub-perceptual perturbations in images, audio, or video are extracted by the encoder; all four frontier vision-language models in a 2024 oncology-imaging study were susceptible (Clusmann et al., *Nature Communications*).
 
-5. **Invisible-character injection and exfiltration.** Tag-block (U+E0000–U+E007F), variation-selector (U+FE00–U+FE0F), and zero-width (U+200B/C/D, U+2060) characters carry instructions or exfiltrate bytes through text that appears benign in standard rendering. The August 2024 ASCII-smuggling PoC against Microsoft 365 Copilot demonstrated MFA-code exfiltration.
+5. **Invisible-character injection and exfiltration** — Tag-block, variation-selector, and zero-width Unicode carry instructions or exfiltrate bytes inside benign-looking text; the August 2024 M365 Copilot ASCII-smuggling PoC exfiltrated an MFA code.
 
-6. **Cross-session memory and RAG corpus poisoning.** An adversarial document written into persistent memory or a RAG corpus influences every future session that reads the tainted entry. As few as five injected documents achieved 97% attack success on Natural Questions (PoisonedRAG, USENIX Security 2025).
+6. **Cross-session memory and RAG corpus poisoning** — one tainted entry in persistent memory or a RAG corpus reaches every future session that reads it; as few as five documents reached 97% attack success on Natural Questions (PoisonedRAG, USENIX Security 2025).
 
-7. **Fine-tuning interface as gradient oracle ("fun-tuning").** An attacker abuses a vendor's fine-tuning API — pairing candidate inputs with a target output and reading the returned per-example loss as a gradient surrogate — to optimize a payload that reliably produces attacker-chosen output (65–82% ASR on Gemini in the original paper), bringing white-box-style optimization to closed-weight deployments.
+7. **Fine-tuning interface as gradient oracle ("fun-tuning")** — an attacker reads per-example loss from a vendor's fine-tuning API to optimize a payload (65–82% ASR on Gemini), bringing white-box-style optimization to closed-weight models.
 
-8. **Multilingual, encoded, or low-resource-language payloads.** Translation to low-resource or code-mixed languages sharply reduces classifier accuracy — refusal rates can fall from ~79% (English) to ~23% on identical content — and encodings (Base64, ROT13) or emoji substitution evade classifiers not trained on the scheme.
+8. **Multilingual, encoded, or low-resource-language payloads** — low-resource or code-mixed translation drops refusal rates from ~79% to ~23% on identical content, and Base64/ROT13/emoji encodings evade classifiers not trained on the scheme.
 
 ---
 


### PR DESCRIPTION
Condensed rewrite of LLM01 (Prompt Injection) for length, per reviewer request — same risk coverage, tighter prose. Follows the same pattern as #93 (LLM02 condense): single file, structure and coverage preserved, prose and reference list trimmed.

**Net: ~6,358 → ~4,205 words (300 → 206 lines), one file.**

### Kept intact
- **Description** and **Types of Prompt Injection** — verbatim.
- **Prevention framing** — the intrinsic-limits paragraph and the lethal-trifecta / LLM06-pairing paragraph, verbatim.
- **All 9 attack scenarios**, each with its `Anatomy: (a)·(b)·(c)` tag.
- **All 25 framework IDs** (OWASP ASI, MITRE ATLAS, MITRE ATT&CK, NIST AI 100-2 E2025, AIVSS, DSGAI) — the Related Frameworks table is kept, not dropped.

### Trimmed
- **11 controls** collapsed to one-line form: dropped the per-control *Addresses / Assumes / Known-limits* scaffolding, but each control keeps its key citation and its single most load-bearing limitation.
- **Scenario prose** tightened (anatomy lines unchanged).
- **Related Frameworks table** grouped by framework with terser relevance cells (all IDs retained).
- **Reference Links** pruned 45 → 34 — removed only orphaned "further-reading" entries not cited anywhere in the body; no inline citation is left dangling.

### Also
- Corrects a stale cross-reference in the Prevention lead-in: the load-bearing-controls pointer **(4, 11) → (4, 8)** (#8 is the capability-budgeting / Rule-of-Two control; #11 is adaptive testing).

Branch is based directly on the current `main`, so it should merge cleanly with no rebase.

Requesting review on whether the reference prune leaves the entry adequately sourced.
