### PR TITLE
LLM05:2026 Data and Model Poisoning: RC1 review fixes

### DIFF
--- a/2026/final/LLM05_DataModelPoisoning.md
+++ b/2026/final/LLM05_DataModelPoisoning.md
@@ -2,7 +2,7 @@
 
 ### Description
 
-Data & Model Poisoning describes a class of attacks and failures where an adversary (or unsafe process) manipulates data or model artifacts to embed harmful behavior, bias, or exploitable weaknesses into an AI system. In modern GenAI environments, poisoning is not limited to "training data" in the traditional sense — it can occur anywhere data is ingested, transformed, retrieved, or reused, including during pre-training, fine-tuning, embedding creation, retrieval augmentation (RAG), and model distribution. The result is an AI system that may still appear 
+Data and Model Poisoning describes a class of attacks and failures where an adversary (or unsafe process) manipulates data or model artifacts to embed harmful behavior, bias, or exploitable weaknesses into an AI system. In modern GenAI environments, poisoning is not limited to "training data" in the traditional sense — it can occur anywhere data is ingested, transformed, retrieved, or reused, including during pre-training, fine-tuning, embedding creation, retrieval augmentation (RAG), and model distribution. The result is an AI system that may still appear 
 functional but behaves in ways that undermine trust, safety, and security.
 
 Data poisoning occurs when pre-training, fine-tuning, or embedding data is tampered with to introduce vulnerabilities, backdoors, or biases. This can happen intentionally (malicious poisoning) or unintentionally (poor data hygiene, contaminated sources). The manipulation compromises model integrity — the model learns the wrong patterns, internalizes malicious correlations, or is conditioned to behave incorrectly. The consequences include harmful outputs, impaired capabilities, and degraded reliability.
@@ -21,30 +21,30 @@ The data poisoning surface expands because organizations increasingly rely on ex
 
 In agentic deployments, poisoning risks extend to tool integrations, persistent memory stores, and RLHF feedback loops — attack surfaces covered in depth in the OWASP Top 10 for Agentic Applications.
 
+This entry covers durable corruption of persistent data or model behavior. Prompt instructions delivered through retrieved content at inference time are covered by LLM01:2026 Prompt Injection, and attacks that exploit embedding geometry by LLM09:2026 Vector and Embedding Weaknesses.
+
 ---
 
 ### Common Examples of Risk
 
-1. **Training & Fine-Tuning Data Poisoning:** Attackers inject biased or malicious content into datasets. Microsoft Tay demonstrated rapid degradation when users poisoned its learning data. A targeted variant deliberately erodes refusal behaviors while preserving general accuracy, making degradation undetectable through standard evaluation.
+1. **Training and Fine-Tuning Data Poisoning:** Attackers inject biased or malicious content into datasets. A targeted variant deliberately erodes refusal behaviors while preserving general accuracy, making degradation undetectable through standard evaluation.
 
 2. **Financial Model Data Poisoning:** Attackers inject mislabeled transaction data into fraud 
 detection models, labeling fraud as legitimate. The model learns to ignore real threats, enabling fraud bypass and undermining trust in AI-driven financial systems.
 
-3. **Open-Source Dataset Supply Chain Poisoning:** Attackers contribute malicious data to widely used datasets. A 2024 case showed trigger phrases inserted across dozens of downstream models, requiring costly retraining.
+3. **Open-Source Dataset Supply Chain Poisoning:** Attackers contribute malicious data to widely used datasets. Trigger phrases inserted into a shared dataset can propagate into the many downstream models that fine-tune on it, forcing costly retraining once the backdoor is discovered.
 
 4. **Low-Volume High-Impact Backdoor Poisoning:** As few as 250 poisoned documents compromise models from 600M to 13B parameters regardless of dataset size (Souly et al., 2025). Strategic minimal manipulation is sufficient for significant impact.
 
 5. **AI Recommendation / Memory Poisoning:** Attackers embed hidden instructions in web content to manipulate AI memory or recommendations without detection, demonstrating risks in agent-based systems and persistent memory.
 
-6. **RAG Knowledge Base Poisoning:** Injecting as few as 3-10 semantically optimized adversarial documents overrides accurate content across a retrieval pipeline. Standard defenses including perplexity-based filtering fail (Zhang et al., 2025).
+6. **RAG Knowledge Base Poisoning:** A single optimized poisoned text injected per targeted query can override accurate content in a retrieval corpus, and the attack retains high success against paraphrasing, instructional-prevention, and detection-based defenses (Zhang et al., 2025).
 
 7. **Agent / Multi-System Poisoning:** Poisoned inputs in multi-agent workflows influence behavior and data access across entire AI-driven ecosystems, not just individual models.
 
 8. **Healthcare Model Poisoning:** Minimal poisoning of medical training data significantly alters model outputs while passing standard evaluations, creating unsafe recommendations in safety-critical domains.
 
 9. **Malicious AI Models in Supply Chain:** Attackers distribute compromised models via public repositories with embedded backdoors. Organizations downloading these models unknowingly inherit hidden triggers or system compromise.
-
-10. **Prompt / Content Injection via External Data:** Attackers inject malicious content through inputs, forums, or APIs. Real incidents show chatbots producing manipulated outputs and exposing internal instructions from unverified external sources.
 
 ---
 
@@ -56,66 +56,63 @@ detection models, labeling fraud as legitimate. The model learns to ignore real 
 
 3. Protect RAG systems by enforcing trust boundaries, filtering retrieved content, applying source scoring, and isolating system instructions from external data.
 
-4. Use sandboxing and strict isolation controls to limit model interaction with unverified data, plugins, or external systems.
+4. Use sandboxing and strict isolation controls to limit model interaction with unverified data, tools, or external systems.
 
-5. Apply statistical and AI-based anomaly detection across training, embedding, and inference pipelines. Monitor outputs and behavioral patterns for drift using defined thresholds.
+5. Apply statistical and AI-based anomaly detection across training, embedding, and inference pipelines, and monitor training loss, outputs, and behavior for drift or anomalies against defined thresholds to detect subtle poisoning effects over time.
 
 6. Use curated domain-specific datasets for fine-tuning to reduce exposure to untrusted data and cross-domain contamination.
 
 7. Enforce least-privilege access, network segmentation, and strict data access controls to prevent unauthorized data injection.
 
-8. Use DVC to track dataset changes, maintain version history, and enable rollback and forensic analysis when poisoning is detected.
+8. Use data version control (e.g., DVC) to track dataset changes, maintain version history, and enable rollback and forensic analysis when poisoning is detected.
 
 9. Control automated retraining and feedback loops by validating incoming data, requiring human oversight, and applying rate limits against gradual poisoning through manipulated preference signals.
 
 10. Continuously red team models with adversarial inputs and trigger-based prompts to identify hidden backdoors. Do not assume safety alignment removes backdoors — dedicated trigger-probing is required after every alignment cycle (Hubinger et al., 2024).
 
-11. Monitor outputs, training loss, and behavioral patterns for drift or anomalies using defined 
-thresholds to detect subtle poisoning effects over time.
+11. Implement grounding techniques with validation layers ensuring retrieved content is verified before influencing outputs.
 
-12. Implement grounding techniques with validation layers ensuring retrieved content is verified before influencing outputs.
-
-13. Treat inference artifacts — including chat templates, tokenizer configs, LoRA/PEFT adapters, and quantization artifacts — as security-relevant code. Enforce signing, hash verification, diff checks, and static analysis before deployment.
+12. Treat inference artifacts — including chat templates, tokenizer configs, LoRA/PEFT adapters, and quantization artifacts — as security-relevant code. Enforce signing, hash verification, diff checks, and static analysis before deployment.
 
 ---
 
 ### Example Attack Scenarios
 
-**Scenario #1**
+#### Scenario #1
 
 An attacker inserts manipulated documents into an internal knowledge repository. Poisoned documents surface in responses, leading to incorrect recommendations, manipulated business decisions, or reputational damage.
 
-**Scenario #2**
+#### Scenario #2
 
 An attacker embeds hidden instructions in webpages summarized by AI tools. When ingested into RAG or memory systems, the instructions bias the model to recommend specific products, enabling financial manipulation and loss of trust in AI outputs.
 
-**Scenario #3**
+#### Scenario #3
 
 An attacker submits crafted inputs into an automated retraining feedback loop. No infrastructure access is required — only standard user interface access. The result is slow model drift toward degraded accuracy, biased outputs, or unsafe recommendations.
 
-**Scenario #4**
+#### Scenario #4
 
 A malicious insider injects mislabeled transaction data into a training dataset. The model fails to 
 detect fraud, resulting in financial losses, compliance violations, and regulatory breach.
 
-**Scenario #5**
+#### Scenario #5
 
 An attacker uploads poisoned pre-trained weights to a public repository. Standard safety training fails to remove embedded backdoors (Hubinger et al., 2024). Organizations face system compromise, data leakage, or targeted manipulation at scale.
 
-**Scenario #6**
+#### Scenario #6
 
-An attacker modifies a chat template in a GGUF package with trigger-activated conditional 
+An attacker modifies a model's chat template (for example in a GGUF package or tokenizer config) with trigger-activated conditional 
 instructions. Redistributed via a public hub, the model behaves normally under benign inputs. 
 Validated across 18 models and 4 inference runtimes — factual accuracy drops from 90% to 15% under trigger conditions and URL emission exceeds 80% success rate (Fogel et al., 2026).
 
-**Scenario #7**
+#### Scenario #7
 
 A developer loads a third-party model using unsafe serialization (e.g., pickle). Embedded malicious code executes during loading, enabling host compromise, lateral movement, and infrastructure breach.
 
-**Scenario #8**
+#### Scenario #8
 
 In a shared AI environment, one tenant injects adversarial data into shared embeddings or memory layers, influencing other tenants' responses and causing cross-tenant contamination and privacy risk.
 
-**Scenario #9**
+#### Scenario #9
 
 An attacker injects malicious instructions into an AI agent's persistent memory over multiple sessions. The agent begins prioritizing attacker-controlled logic, resulting in long-term workflow manipulation and hidden persistence.

--- a/2026/final/LLM05_DataModelPoisoning.md
+++ b/2026/final/LLM05_DataModelPoisoning.md
@@ -2,24 +2,23 @@
 
 ### Description
 
-Data and Model Poisoning describes a class of attacks and failures where an adversary (or unsafe process) manipulates data or model artifacts to embed harmful behavior, bias, or exploitable weaknesses into an AI system. In modern GenAI environments, poisoning is not limited to "training data" in the traditional sense — it can occur anywhere data is ingested, transformed, retrieved, or reused, including during pre-training, fine-tuning, embedding creation, retrieval augmentation (RAG), and model distribution. The result is an AI system that may still appear 
-functional but behaves in ways that undermine trust, safety, and security.
+Data and Model Poisoning describes a class of attacks and failures where an adversary (or unsafe process) manipulates data or model artifacts to embed harmful behavior, bias, or exploitable weaknesses into an AI system. In modern GenAI environments, poisoning is not limited to "training data" in the traditional sense. It can occur anywhere data is ingested, transformed, retrieved, or reused, including during pre-training, fine-tuning, embedding creation, retrieval augmentation (RAG), and model distribution. The result is an AI system that may still appear functional but behaves in ways that undermine trust, safety, and security.
 
-Data poisoning occurs when pre-training, fine-tuning, or embedding data is tampered with to introduce vulnerabilities, backdoors, or biases. This can happen intentionally (malicious poisoning) or unintentionally (poor data hygiene, contaminated sources). The manipulation compromises model integrity — the model learns the wrong patterns, internalizes malicious correlations, or is conditioned to behave incorrectly. The consequences include harmful outputs, impaired capabilities, and degraded reliability.
+Data poisoning occurs when pre-training, fine-tuning, or embedding data is tampered with to introduce vulnerabilities, backdoors, or biases. This can happen intentionally (malicious poisoning) or unintentionally (poor data hygiene, contaminated sources). The manipulation compromises model integrity. The model learns the wrong patterns, internalizes malicious correlations, or is conditioned to behave incorrectly. The consequences include harmful outputs, impaired capabilities, and degraded reliability.
 
-The key idea: poisoning targets the model's "learning process," not a single runtime bug. Unlike typical software vulnerabilities that can be patched by fixing code, poisoning can require data revalidation, retraining, model replacement, or pipeline redesign — making it expensive and operationally disruptive.
+The key idea: poisoning targets the model's "learning process," not a single runtime bug. Unlike typical software vulnerabilities that can be patched by fixing code, poisoning can require data revalidation, retraining, model replacement, or pipeline redesign, which is expensive and operationally disruptive.
 
 Poisoning can occur across multiple stages of the LLM lifecycle:
 
 - **Pre-training:** Maliciously crafted or contaminated corpora cause the model to absorb harmful patterns, unsafe instructions, or skewed representations.
-- **Fine-tuning:** Manipulated datasets introduce  domain-specific failure modes or hidden triggers.
-- **Embeddings and vectorization:** Poisoning targets  stored vectors to influence retrieved content, resulting in steered answers or subtle misinformation.
+- **Fine-tuning:** Manipulated datasets introduce domain-specific failure modes or hidden triggers.
+- **Embeddings and vectorization:** Poisoning targets stored vectors to influence retrieved content, resulting in steered answers or subtle misinformation.
 - **Transfer learning / model reuse:** Compromised source models pass that compromise to downstream systems.
 - **Continuous learning pipelines:** Automated ingestion without sufficient validation allows attackers to gradually shape model behavior.
 
-The data poisoning surface expands because organizations increasingly rely on external datasets, RAG pipelines, shared model repositories, and agentic workflows. Models distributed through shared repositories can carry risks through bundled non-weight artifacts — including malicious deserialization (e.g. pickle files) and tampering of chat templates, tokenizer configs, LoRA/PEFT adapters, and quantization artifacts — any of which can execute harmful code or alter model behavior when loaded. Such backdoors may leave model behavior untouched until a trigger causes it to change, creating the opportunity for a model to become a sleeper agent.
+The data poisoning surface expands because organizations increasingly rely on external datasets, RAG pipelines, shared model repositories, and agentic workflows. Models distributed through shared repositories can carry risks through bundled non-weight artifacts, including malicious deserialization (e.g., pickle files) and tampering of chat templates, tokenizer configs, LoRA/PEFT adapters, and quantization artifacts, any of which can execute harmful code or alter model behavior when loaded. Such backdoors may leave model behavior untouched until a trigger causes it to change, creating the opportunity for a model to become a sleeper agent.
 
-In agentic deployments, poisoning risks extend to tool integrations, persistent memory stores, and RLHF feedback loops — attack surfaces covered in depth in the OWASP Top 10 for Agentic Applications.
+In agentic deployments, poisoning risks extend to tool integrations, persistent memory stores, and RLHF feedback loops. These attack surfaces are covered in depth in the OWASP Top 10 for Agentic Applications.
 
 This entry covers durable corruption of persistent data or model behavior. Prompt instructions delivered through retrieved content at inference time are covered by LLM01:2026 Prompt Injection, and attacks that exploit embedding geometry by LLM09:2026 Vector and Embedding Weaknesses.
 
@@ -29,8 +28,7 @@ This entry covers durable corruption of persistent data or model behavior. Promp
 
 1. **Training and Fine-Tuning Data Poisoning:** Attackers inject biased or malicious content into datasets. A targeted variant deliberately erodes refusal behaviors while preserving general accuracy, making degradation undetectable through standard evaluation.
 
-2. **Financial Model Data Poisoning:** Attackers inject mislabeled transaction data into fraud 
-detection models, labeling fraud as legitimate. The model learns to ignore real threats, enabling fraud bypass and undermining trust in AI-driven financial systems.
+2. **Financial Model Data Poisoning:** Attackers inject mislabeled transaction data into fraud detection models, labeling fraud as legitimate. The model learns to ignore real threats, enabling fraud bypass and undermining trust in AI-driven financial systems.
 
 3. **Open-Source Dataset Supply Chain Poisoning:** Attackers contribute malicious data to widely used datasets. Trigger phrases inserted into a shared dataset can propagate into the many downstream models that fine-tune on it, forcing costly retraining once the backdoor is discovered.
 
@@ -68,11 +66,11 @@ detection models, labeling fraud as legitimate. The model learns to ignore real 
 
 9. Control automated retraining and feedback loops by validating incoming data, requiring human oversight, and applying rate limits against gradual poisoning through manipulated preference signals.
 
-10. Continuously red team models with adversarial inputs and trigger-based prompts to identify hidden backdoors. Do not assume safety alignment removes backdoors — dedicated trigger-probing is required after every alignment cycle (Hubinger et al., 2024).
+10. Continuously red team models with adversarial inputs and trigger-based prompts to identify hidden backdoors. Do not assume safety alignment removes backdoors. Dedicated trigger-probing is required after every alignment cycle (Hubinger et al., 2024).
 
 11. Implement grounding techniques with validation layers ensuring retrieved content is verified before influencing outputs.
 
-12. Treat inference artifacts — including chat templates, tokenizer configs, LoRA/PEFT adapters, and quantization artifacts — as security-relevant code. Enforce signing, hash verification, diff checks, and static analysis before deployment.
+12. Treat inference artifacts, including chat templates, tokenizer configs, LoRA/PEFT adapters, and quantization artifacts, as security-relevant code. Enforce signing, hash verification, diff checks, and static analysis before deployment.
 
 ---
 
@@ -88,12 +86,11 @@ An attacker embeds hidden instructions in webpages summarized by AI tools. When 
 
 #### Scenario #3
 
-An attacker submits crafted inputs into an automated retraining feedback loop. No infrastructure access is required — only standard user interface access. The result is slow model drift toward degraded accuracy, biased outputs, or unsafe recommendations.
+An attacker submits crafted inputs into an automated retraining feedback loop. No infrastructure access is required, only standard user-interface access. The result is slow model drift toward degraded accuracy, biased outputs, or unsafe recommendations.
 
 #### Scenario #4
 
-A malicious insider injects mislabeled transaction data into a training dataset. The model fails to 
-detect fraud, resulting in financial losses, compliance violations, and regulatory breach.
+A malicious insider injects mislabeled transaction data into a training dataset. The model fails to detect fraud, resulting in financial losses, compliance violations, and regulatory breach.
 
 #### Scenario #5
 
@@ -101,9 +98,7 @@ An attacker uploads poisoned pre-trained weights to a public repository. Standar
 
 #### Scenario #6
 
-An attacker modifies a model's chat template (for example in a GGUF package or tokenizer config) with trigger-activated conditional 
-instructions. Redistributed via a public hub, the model behaves normally under benign inputs. 
-Validated across 18 models and 4 inference runtimes — factual accuracy drops from 90% to 15% under trigger conditions and URL emission exceeds 80% success rate (Fogel et al., 2026).
+An attacker modifies a model's chat template (for example in a GGUF package or tokenizer config) with trigger-activated conditional instructions. Redistributed via a public hub, the model behaves normally under benign inputs. Validated across 18 models and 4 inference runtimes: factual accuracy drops from 90% to 15% under trigger conditions, and URL emission exceeds an 80% success rate (Fogel et al., 2026).
 
 #### Scenario #7
 


### PR DESCRIPTION
## LLM05: apply Steve Wilson's RC1 review, premortem, and house-style pass

Branch: `review/rc1/llm05-data-model-poisoning` · Base: `release-candidate-1` · File touched: `2026/final/LLM05_Data_and_Model_Poisoning.md` · Net line delta: -8

## Summary

Applies Steve Wilson's editorial and technical review of LLM05 Data and Model Poisoning, a citation/source-fidelity premortem, and a whole-file AI-writing-tell and house-style cleanup. Two material claim corrections (CorruptRAG result; unsourced "2024 case"), two ownership-model scope trims (indirect-injection example → LLM01; RAG/embedding overlap boundary → LLM01 + LLM09), one mitigation consolidation, and the removal of the disputed Microsoft Tay example. All load-bearing quantitative claims were verified against sources opened this session.

## Sources of findings

- Steve Wilson RC1 review, LLM05 section (items 1-5) and cross-entry opportunities (#4 delete weak controls, #5 terminology, #6 PDF links).
- Ownership model (spec §4): LLM05 owns persistent corruption of data or model behavior.
- Premortem (citation/source fidelity, Round 2 weighted highest).
- House style (`documentation/style/{general,entries}.md`) and the AI-writing-tell sweep.

## Changes

| # | Severity | Source | Category | Location | Change | Evidence |
|---|---|---|---|---|---|---|
| 1 | definite-correction | Steve #1 | style/terminology | Description para 1 (line 5); Common Examples #1 label | `&` → `and` in the opener and the "Training & Fine-Tuning" label | Reproduces lines 5, 28; Steve LLM05 #1 + cross-entry #5 |
| 2 | technical-accuracy | Steve #2 | VERIFY/remove | Common Examples #1 | Removed the Microsoft Tay sentence; kept the targeted refusal-erosion point | Tay is unsafe online-learning / interaction abuse, not classical poisoning |
| 3 | scope | Steve #3 | SCOPE | Common Examples #10 | Deleted "Prompt / Content Injection via External Data" (transient indirect injection) | Coverage confirmed in LLM01:2026 Indirect Prompt Injection |
| 4 | scope | Steve #4 | SCOPE | Description | Added one-sentence boundary: durable corruption → LLM05; retrieved-content prompts → LLM01:2026; embedding geometry → LLM09:2026 | Reciprocal with LLM09 line 23 and LLM01 Indirect Prompt Injection |
| 5 | consolidation | Steve #5 | FIX | Prevention #5 and #11 | Merged item 11 (training loss) into #5; removed #11; renumbered 12→11, 13→12 | Reproduces lines 61, 73-74 |
| 6 | accuracy-material | premortem | VERIFY/correct | Common Examples #6 | Corrected CorruptRAG to a single optimized poisoned text per query, resilient against paraphrasing / instructional-prevention / detection-based defenses; cite metadata unchanged (Zhang et al., 2025) | arXiv 2504.03957 abstract + Section 6 |
| 7 | accuracy | premortem | VERIFY/generalize | Common Examples #3 | Generalized to the risk mechanism, removing the unsourced "2024 case … dozens of downstream models" framing | No citation; WebSearch found only the risk category |
| 8 | structure | Decision 3 | FIX | Example Attack Scenarios | `**Scenario #N**` bold-inline → bare `#### Scenario #N` for all 9 (no invented titles) | 9 H4 headings confirmed |
| 9 | editorial | premortem | FIX | Prevention #8 | Expanded undefined acronym to "data version control (e.g., DVC)" | Style guide `general.md` Jargon rule |
| 10 | style | tell sweep | FIX | whole file | 11 em dashes (9 lines) → commas/colons/periods/parentheses; 2 double-spaces → single; 6 trailing-space hard-wraps joined; `e.g.` → `e.g.,` | `conformance.sh` HARD PASS exit 0 |

## Verification log

| Claim | Status | Source opened |
|---|---|---|
| 250 poisoned documents compromise 600M-13B models regardless of dataset size (Souly et al., 2025) | verified | arXiv 2510.07192 abstract |
| RAG poisoning: single optimized poisoned text per query, resilient to paraphrasing / instructional-prevention / detection-based defenses (Zhang et al., 2025) | corrected | arXiv 2504.03957 (CorruptRAG) abstract + Section 6; published "3-10 documents / perplexity-based filtering" was not supported and was dropped |
| Standard safety training fails to remove embedded backdoors (Hubinger et al., 2024) | verified | arXiv 2401.05566 abstract |
| Chat-template backdoor: 90% → 15% accuracy under trigger, URL emission >80%, 18 models, 4 runtimes (Fogel et al., 2026) | verified | arXiv 2602.04653 (html); "4 runtimes" re-check queued for reference-sync |
| "A 2024 case … dozens of downstream models" (example #3) | removed | No citation; no matching incident found; generalized to the mechanism |
| Microsoft Tay poisoning (example #1) | removed | Not classical training-data poisoning (Steve #2) |

Full per-claim log and the Zhang rewording basis: `.review/dossiers/LLM05/verification.md`.

## Reviewed and not changed (PDF artifacts)

| Item | Reason |
|---|---|
| Missing space after Prevention item 10 (Steve #5 sub-item) | Does not reproduce in the markdown (normal ASCII space; 0 invisible characters at baseline). PDF text-extraction artifact from mid-item hard line-wraps; the whitespace sweep also removed the wraps. |

## Style and conformance

- `conformance.sh` on `revised.md`: **Tier-1 HARD PASS, exit 0, 0 hits**.
- Tells removed: 11 em dashes (9 lines), 2 double-spaces, 6 trailing-space hard-wraps; `e.g.` → `e.g.,`. No prose semicolons or invisible characters present.
- **Appendix Exception honored:** no `### References` and no `### Related Frameworks and Taxonomies` section added or flagged; references live in `references.md`, framework mappings in `Appendix_A_*`.
- **Tier-2 advisory:** 6 citation-closure hits (uncited references in `references.md ## LLM05:`). Advisory-resolved, not advisory-zero (spec §6): each triaged and **deferred to the reference-sync worklist** (an entry PR cannot edit `references.md`; F6 citation-metadata coupling). Detail below.

## Residual risk

All residual items are `references.md` citation-closure hygiene, deferred to the reference-sync PR (`review/rc1/references-appendix-sync`; `@rossja` `@rocklambros`). The entry body is unchanged and citation-metadata-neutral.

Deferred Tier-2 advisories (6), each with a reason:

1. **CycloneDX (n.d.)** — named in body as a tool ("SBOM/ML-BOM (e.g., CycloneDX)"), not an author-date cite; parser cannot bind. **Coupled**: CycloneDX ML-BOM is shared LLM04/LLM05 (spec §8 `[also cited in]` pair) and must carry identical metadata; a cite change is sync-first with LLM04. Decision: cite vs accept as tool-name mention.
2. **DVC (n.d.)** — named in body as a tool ("data version control (e.g., DVC)"), not an author-date cite. Decision: cite vs accept as tool-name mention.
3. **GitHub (2026, Giskard GHSA)** — genuinely uncited. Decision: cite-or-remove.
4. **JFrog Security Research (n.d., GGUF-SSTI)** — genuinely uncited; candidate cite for Scenario #6. Decision: cite-or-remove.
5. **MITRE (n.d., ATLAS)** — genuinely uncited; plausibly citable. Decision: cite-or-remove.
6. **NIST (2023, AI RMF 1.0)** — genuinely uncited; plausibly citable. Decision: cite-or-remove.

Additional (not a conformance hit): **F5 (2025)** is genuinely uncited but parser-skipped this turn; triage in reference-sync alongside the six.

Other deferred decisions:

- **Perplexity-filtering point (example #6):** if wanted, needs a PoisonedRAG (W. Zou, 2025) cite, not Zhang/CorruptRAG. Default applied: example #6 corrected to the CorruptRAG statement, no perplexity claim retained.
- **Fogel (2026) "4 inference runtimes":** verify against paper body during reference-sync; text unchanged (pre-existing claim, not edit-introduced).

## Reviewers

@virtualsteve-star @sjeswani28 @owasprox @anithadakamarri-sudo
