### PR TITLE
LLM06:2026 Unbounded Consumption: RC1 review fixes

### DIFF
--- a/2026/final/LLM06_UnboundedConsumption.md
+++ b/2026/final/LLM06_UnboundedConsumption.md
@@ -2,104 +2,122 @@
 
 ### Description
 
-Unbounded Consumption occurs when an LLM application allows excessive and uncontrolled inferences, enabling attackers to disrupt service availability, inflict unsustainable financial costs, or steal intellectual property through model cloning, all by exploiting a common class of vulnerability: the absence of adequate controls over how resources are consumed. 
+Unbounded Consumption occurs when an LLM application allows excessive and uncontrolled inferences, enabling attackers to disrupt service availability, inflict unsustainable financial costs, or steal intellectual property through model cloning, all by exploiting a common class of vulnerability: the absence of adequate controls over how resources are consumed.
 
-The high computational demands of LLMs, particularly in cloud and pay-per-token environments, make them inherently susceptible to resource exploitation and unauthorized usage. A defining characteristic of this threat is cost asymmetry. Attackers can trigger disproportionately expensive computation at negligible cost to themselves, whether through crafted prompts, stolen credentials, or manipulated workflows. 
+The high computational demands of LLMs, particularly in cloud and pay-per-token environments, make them inherently susceptible to resource exploitation and unauthorized usage. A defining characteristic of this threat is cost asymmetry. Attackers can trigger disproportionately expensive computation at negligible cost to themselves, whether through crafted prompts, stolen credentials, or manipulated workflows.
 
-This risk is compounded by the growing adoption of extended-thinking and reasoning models with unbounded token generation, multi-modal models that dramatically expand per-request compute costs, agentic architectures and tool-use protocols (such as MCP) that amplify a single request into cascading downstream operations, and shared inference infrastructure that introduces new side-channel and supply-chain attack surfaces. Traditional request-rate limiting alone is no longer sufficient; effective defense demands token-aware cost controls, hard spending caps, agent-level circuit breakers, and continuous cost-attribution monitoring.
-
+This risk is compounded by the growing adoption of extended-thinking and reasoning models with large or insufficiently constrained output budgets, multimodal models that substantially increase per-request compute costs, agentic architectures and tool-use protocols (such as MCP) that amplify a single request into cascading downstream operations, and shared inference infrastructure that introduces new supply-chain attack surfaces. Traditional request-rate limiting alone is no longer sufficient. Effective defense demands token-aware cost controls, hard spending caps, agent-level circuit breakers, and continuous cost-attribution monitoring.
 
 ### Common Examples of Risk
 
 #### 1. Variable-Length Input Flood and Output Explosion
-  Attackers can overload the LLM with numerous inputs of varying lengths, exploiting processing inefficiencies. This can deplete resources and potentially render the system unresponsive, significantly impacting service availability. This also includes output explosion via fine-tuning poisoning where a single malicious training sample breaks the model’s end-of-sequence behavior, pushing output to maximum tokens on every request (Gao et al., 2024).
+
+Attackers can overload the LLM with numerous inputs of varying lengths, exploiting processing inefficiencies. This can deplete resources and potentially render the system unresponsive, significantly impacting service availability. This also includes output explosion via fine-tuning poisoning, where a single malicious training sample breaks the model's end-of-sequence behavior and pushes output to the maximum length on every request (Gao et al., 2024).
 
 #### 2. Denial of Wallet (DoW)
-  By initiating a high volume of operations, attackers exploit the cost-per-use model of cloud-based AI services, leading to unsustainable financial burdens on the provider and risking financial ruin.
 
-#### 3. Continuous Input Overflow
-  Continuously sending inputs that exceed the LLM’s context window can lead to excessive computational resource use, resulting in service degradation and operational disruptions.
+By initiating a high volume of operations, attackers exploit the cost-per-use model of cloud-based AI services, leading to unsustainable financial burdens on the provider and risking financial ruin.
+
+#### 3. Large-Context Abuse
+
+Repeated near-limit requests, context accumulation, and application-side rechunking consume disproportionate compute and memory. Many APIs reject inputs that exceed the context window outright, so the durable risk comes from requests that stay just within limits while inflating per-request cost.
 
 #### 4. Reasoning-Loop and Thinking-Token Exhaustion
-  Attackers craft short, benign-looking prompts that result in resource exhaustion by forcing extended-thinking models into prolonged or non-terminating reasoning loops, consuming massive thinking-token budgets while bypassing input-size filters (Li et al., 2025). Because these prompts are small and appear legitimate, standard input validation provides no protection.
+
+Attackers craft short, benign-looking prompts that result in resource exhaustion by forcing extended-thinking models into prolonged or non-terminating reasoning loops, consuming massive thinking-token budgets while bypassing input-size filters (Li et al., 2025). Because these prompts are small and appear legitimate, standard input validation provides no protection.
 
 #### 5. Adversarial Inputs Optimized for Resource Overconsumption
-  Attackers use optimization techniques to craft inputs that maximize computational cost. This is distinct from simply asking the model to perform a resource-intensive task and includes sponge examples (Shumailov et al., 2020) and adversarial visual perturbations. This includes optimization of adversarial input with gradient-based and gradient-free techniques. Unlike reasoning-loop attacks these require explicit optimization over the input space rather than prompt design alone. 
+
+Attackers use optimization techniques to craft inputs that maximize computational cost. This is distinct from simply asking the model to perform a resource-intensive task and includes sponge examples (Shumailov et al., 2020) and adversarial visual perturbations. It covers optimization of adversarial input with gradient-based and gradient-free techniques. Unlike reasoning-loop attacks, these require explicit optimization over the input space rather than prompt design alone.
 
 #### 6. Multimodal Inputs and Outputs
-  For multi-modal models that are more cost-intensive than the text-only services, the extent of the computation cost is exacerbated. In many cases, this can result in 10 to 100 times the cost of text-based models.
+
+Multimodal models convert images, audio, and video into large numbers of tokens, so a single request can cost substantially more than a comparable text-only request. The exact overhead varies with the model, provider, resolution, media duration, and preprocessing pipeline.
 
 #### 7. Model Extraction and Distillation Theft
-  Attackers query the model API with crafted inputs to collect sufficient outputs to replicate a partial model or fine-tune a functional equivalent. Exposure of logits and log-probabilities significantly accelerates extraction (Carlini et al., 2024).
 
-#### 8. Side-Channel Attacks
-  Malicious attackers may exploit input filtering techniques of the LLM to execute side-channel attacks, harvesting model weights and architectural information. This could compromise the model’s security and lead to further exploitation.
+Attackers query the model API with crafted inputs to collect sufficient outputs to replicate a partial model or fine-tune a functional equivalent. Exposure of logits and log-probabilities significantly accelerates extraction (Carlini et al., 2024).
 
-#### 9. Agent-Tool Interactions Flooding Model Resources
-  Attackers can publish tools that overuse LLM resources by forcing an LLM-based application into recursive or infinite tool calling loops. This could cause seemingly legitimate tool actions to result in financial burdens or compromise quality of service. Furthermore, when one tool-call fans out into a much larger quantity of actions, this can result in token overuse if the LLM needs to manage hundreds of tool calls spawned from one task.
+#### 8. Agent-Tool Interactions Flooding Model Resources
 
-#### 10. Inference Infrastructure Exploitation
-  Attackers target vulnerabilities in LLM serving frameworks (vLLM, TensorRT-LLM, SGLang, Triton, Ollama) to crash services or exhaust model resources through unsafe deserialization flaws, special-token injection, injected chat templates. 
+Attackers can publish tools that overuse LLM resources by forcing an LLM-based application into recursive or infinite tool-calling loops. This could cause seemingly legitimate tool actions to result in financial burdens or compromise quality of service. When one tool call fans out into a much larger number of actions, the LLM may need to manage hundreds of calls spawned from a single task, driving token overuse.
 
+#### 9. Inference Infrastructure Exploitation
+
+Attackers target vulnerabilities in LLM serving frameworks (vLLM, TensorRT-LLM, SGLang, Triton, Ollama) to crash services or exhaust model resources through unsafe deserialization flaws, special-token injection, and injected chat templates.
 
 ### Prevention and Mitigation Strategies
 
 #### 1. Rate Limiting & Input Size Validation
-  Apply rate limiting and user quotas to restrict the number of requests a single source entity can make in a given time period. Move beyond requests per second to enforce limits on tokens-per-minute, tokens-per-day and estimated cost per request. Use pre-flight token estimation to reject requests before inference begins. This includes validation to ensure inputs do not exceed reasonable size limits.
+
+Apply rate limiting and user quotas to restrict the number of requests a single source entity can make in a given time period. Move beyond requests per second to enforce limits on tokens-per-minute, tokens-per-day, and estimated cost per request. Use pre-flight token estimation to reject requests before inference begins. This includes validation to ensure inputs do not exceed reasonable size limits.
 
 #### 2. Hard Spending Caps
-  Set non-overridable budget ceilings per API key, user, team, and cloud account. These must be enforcement mechanisms that halt inference when exceeded, not merely alerting thresholds that can be outpaced by fast-accumulating workloads. Furthermore, spending caps need to factor in cost differences between different modalities and tool protocols.
+
+Set non-overridable budget ceilings per API key, user, team, and cloud account. These must be enforcement mechanisms that halt inference when exceeded, rather than alerting thresholds that fast-accumulating workloads can outpace. Spending caps should also account for cost differences between modalities and tool protocols.
 
 #### 3. Resource Allocation Management
-  Monitor and manage resource allocation dynamically to prevent any single user or request from consuming excessive resources.
+
+Monitor and manage resource allocation dynamically to prevent any single user or request from consuming excessive resources.
 
 #### 4. Sandbox Techniques
-  Restrict the LLM’s access to network resources, internal services, and APIs. This is particularly significant for all common scenarios as it encompasses insider risks and threats. Furthermore, it governs the extent of access the LLM application has to data and resources, thereby serving as a crucial control mechanism to mitigate or prevent side-channel attacks.
+
+Restrict the LLM's access to network resources, internal services, and APIs. Constraining what the application can reach limits an attacker's ability to exfiltrate extracted model information or data to an external destination.
 
 #### 5. Graceful Degradation
-  Design the system to degrade gracefully under heavy load, maintaining partial functionality rather than complete failure.
+
+Design the system to degrade gracefully under heavy load, maintaining partial functionality rather than complete failure.
 
 #### 6. Limit Queued Actions and Scale Robustly
-  Implement restrictions on the number of queued actions and total actions, while incorporating dynamic scaling and load balancing to handle varying demands and ensure consistent system performance.
+
+Implement restrictions on the number of queued actions and total actions, while incorporating dynamic scaling and load balancing to handle varying demands and ensure consistent system performance.
 
 #### 7. Scan for Adversarial Perturbations
-  Scan model inputs, particularly visual inputs to LVLMs (large visual language models) for evidence of adversarial perturbations that could cause model resource overconsumption.
+
+Scan model inputs, particularly visual inputs to LVLMs (large visual language models), for evidence of adversarial perturbations that could cause model resource overconsumption.
 
 #### 8. Detect Resource-Intensive Tool Interactions
-  Monitor agent-tool interactions to identify if a particular session appears to be causing a recursive or resource-intensive action without a clear end state. Establish baselines of normal tool behavior in order to detect if a particular tool is deviating from standard token consumption patterns.
-  
+
+Monitor agent-tool interactions to identify if a particular session appears to be causing a recursive or resource-intensive action without a clear end state. Establish baselines of normal tool behavior in order to detect if a particular tool is deviating from standard token consumption patterns.
+
 #### 9. Agentic Circuit Breakers
-  Enforce step limits, recursion depth limits, time limits, and per-run cost ceilings on all agent executions. Use state hashing to detect recursive loops.
-  
+
+Enforce step limits, recursion depth limits, time limits, and per-run cost ceilings on all agent executions. Use state hashing to detect recursive loops.
+
 #### 10. Inference Infrastructure Hardening
-  Keep serving frameworks updated. Disable unsafe deserialization, restrict special-token passthrough, and enforce authentication on all inference endpoints. 
-  
+
+Keep serving frameworks updated. Disable unsafe deserialization, restrict special-token passthrough, and enforce authentication on all inference endpoints.
 
 ### Example Attack Scenarios
 
 #### Scenario #1: Uncontrolled Input Size
-  An attacker submits an unusually large input to an LLM application that processes text data, resulting in excessive memory usage and CPU load, potentially crashing the system or significantly slowing down the service.
+
+An attacker submits an unusually large input to an LLM application that processes text data, resulting in excessive memory usage and CPU load, potentially crashing the system or significantly slowing down the service.
 
 #### Scenario #2: Repeated Requests
-  An attacker transmits a high volume of requests to the LLM API, causing excessive consumption of computational resources and making the service unavailable to legitimate users.
+
+An attacker transmits a high volume of requests to the LLM API, causing excessive consumption of computational resources and making the service unavailable to legitimate users.
 
 #### Scenario #3: Resource-Intensive Queries
-  An attacker crafts specific inputs designed to trigger the LLM's most computationally expensive processes, leading to prolonged GPU usage and potential system failure.
+
+An attacker crafts specific inputs designed to trigger the LLM's most computationally expensive processes, leading to prolonged GPU usage and potential system failure.
 
 #### Scenario #4: Denial of Wallet (DoW)
-  An attacker generates excessive operations to exploit the pay-per-use model of cloud-based AI services, causing unsustainable costs for the service provider.
+
+An attacker generates excessive operations to exploit the pay-per-use model of cloud-based AI services, causing unsustainable costs for the service provider.
 
 #### Scenario #5: Functional Model Replication
-  An attacker uses the LLM's API to generate synthetic training data and fine-tunes another model, creating a functional equivalent and bypassing traditional model extraction limitations.
+
+An attacker uses the LLM's API to generate synthetic training data and fine-tunes another model, creating a functional equivalent and bypassing traditional model extraction limitations.
 
 #### Scenario #6: Perturbations in LVLM Image Input
-  An attacker crafts adversarial image inputs that include perturbations optimized to cause an LVLM to overconsume tokens in its output (Gao et al., 2025).
+
+An attacker crafts adversarial image inputs that include perturbations optimized to cause an LVLM to overconsume tokens in its output (Gao et al., 2025).
 
 #### Scenario #7: Multi-turn Tool Calling Loops and Tool Call Fan-Out
-  The attacker can publish a malicious tool (e.g. via a Claude Skill on an open-source repository) that instructs an agent to perform recursive cyclical tasks, or tasks that require a large number of tool calls. Developers incorporating that tool into their agents then risk causing excessive token consumption and service instability.
 
-#### Scenario #8: Bypassing System Input Filtering
-  A malicious attacker bypasses input filtering techniques and preambles of the LLM to perform a side-channel attack and retrieve model information to a remote controlled resource under their control.
+The attacker can publish a malicious tool (e.g. via a Claude Skill on an open-source repository) that instructs an agent to perform recursive cyclical tasks, or tasks that require a large number of tool calls. Developers incorporating that tool into their agents then risk causing excessive token consumption and service instability.
 
-#### Scenario #9: Growing LLM Context in Agentic Sessions
-  An attacker or a benign user maintains an open agentic session, gradually injecting content. After some 100 turns, each inference re-processes full context. Turn 1: $0.001. Turn 100: $0.50. In aggregate, this results in hundreds of dollars of spend. No single request triggers rate limits because each is individually within budget.
+#### Scenario #8: Growing LLM Context in Agentic Sessions
+
+An attacker or a benign user maintains an open agentic session, gradually injecting content so that each inference re-processes the full accumulated context. Per-turn cost climbs as the context grows, from roughly $0.001 on the first turn to about $0.50 by turn 100. No single request triggers rate limits because each stays individually within budget, yet the aggregate across many concurrent or long-lived sessions reaches hundreds of dollars.

--- a/2026/final/LLM06_UnboundedConsumption.md
+++ b/2026/final/LLM06_UnboundedConsumption.md
@@ -36,7 +36,7 @@ Multimodal models convert images, audio, and video into large numbers of tokens,
 
 #### 7. Model Extraction and Distillation Theft
 
-Attackers query the model API with crafted inputs to collect sufficient outputs to replicate a partial model or fine-tune a functional equivalent. Exposure of logits and log-probabilities significantly accelerates extraction (Carlini et al., 2024).
+Attackers query the model API with crafted inputs to collect sufficient outputs to replicate a partial model or fine-tune a functional equivalent. Exposure of logits and log-probabilities significantly accelerates extraction (Carlini et al., 2024). Side-channel extraction of model weights or architecture through timing or shared-infrastructure observation is covered by LLM02:2026 Sensitive Information Disclosure.
 
 #### 8. Agent-Tool Interactions Flooding Model Resources
 


### PR DESCRIPTION
## Summary

Applies the RC1 editorial and technical review to LLM06:2026 Unbounded Consumption. Corrects the inherited-2025 "unbounded token generation" and "Continuous Input Overflow" wording, deletes the incoherent side-channel risk example and its scenario (coverage confirmed in LLM06 model-extraction items plus LLM02:2026), generalizes an unsupported "10 to 100 times" multimodal-cost claim, corrects the Scenario #9 cost arithmetic, and removes the AI-writing tells (one prose semicolon, three "Furthermore," one "crucial," plus two softened importance-inflation phrases). Net +18 lines (27 blank-line-after-heading insertions minus 9 net content-line deletions).

## Sources of findings

- Steve Wilson, "Editorial and Technical Review of the 2026 OWASP Top 10 for LLM Applications RC1," section LLM06 (`.review/steve_review.md`)
- Premortem pass on the entry as manuscript, and live source verification against this entry, 2026-07-13

## Changes

| # | Severity | Source | Category | Location | Change | Evidence |
|---|---|---|---|---|---|---|
| 1 | Med | Wilson | Correctness | Description, para 3 | "unbounded token generation" -> "large or insufficiently constrained output budgets" | Steve #1 (finite-but-uncontrolled reality) |
| 2 | Med | Wilson | Correctness | Common Examples #3 | "Continuous Input Overflow" -> "Large-Context Abuse" (near-limit requests, context accumulation, rechunking; over-limit inputs usually rejected outright) | Steve #2 |
| 3 | High | Wilson / scope | Scope | Common Examples #8 + Scenario #8 | Deleted the incoherent side-channel example and scenario; description "side-channel and supply-chain" trimmed to "supply-chain"; mitigation #4 reframed to limiting exfiltration of extracted model information | Coverage: LLM06 #7 Model Extraction + LLM02:2026 sec.5 (Carlini logit-bias channel) |
| 4 | High | Verify | Accuracy | Common Examples #6 | "10 to 100 times the cost of text-based models" -> "substantially more than a comparable text-only request" | Anthropic vision docs; no canonical 10-100x source |
| 5 | High | Verify | Accuracy | Scenario #9 (->#8) | "$0.001 -> $0.50 -> hundreds of dollars" single-session leap corrected; "hundreds" reattributed to aggregate across many sessions | Arithmetic check (~$25/session over 100 turns) |
| 6 | Low | Wilson | Terminology | Whole file | "multi-modal" -> "multimodal" (matches LLM02:2026) | Steve cross-entry #5 |
| 7 | - | Style | Tells | Description; mitigations #2/#4; example #8 | 1 prose semicolon split into two sentences; 3x "Furthermore" + 1x "crucial" removed; "dramatically" -> "substantially," "particularly significant" filler dropped | conformance Tier-1 HARD PASS; Tier-2 AI-vocabulary now 0 |
| 8 | - | Structure | Renumber | Examples, Scenarios | Common Examples 1-10 -> 1-9; Scenarios 1-9 -> 1-8 (after the side-channel deletion) | Decision 3 |

## Verification log

Five inline-cited claims verified against canonical arXiv sources; two numeric claims corrected/generalized; none removed; none parked. Full per-claim table in `verification.md`.

| Claim | Status | Source opened |
|---|---|---|
| Example #1 single-sample output explosion (Gao et al., 2024) | verified | arXiv:2410.10760 abstract |
| Example #4 infinite-thinking loops (Li et al., 2025) | verified | arXiv:2512.07086 (ThinkTrap, NDSS 2026) abstract |
| Example #5 sponge examples (Shumailov et al., 2020) | verified | arXiv:2006.03463 abstract |
| Example #7 logit-bias/logprob extraction (Carlini et al., 2024) | verified | arXiv:2403.06634 + ICML 2024 project page |
| Scenario #6 LVLM perturbation token overconsumption (Gao et al., 2025) | verified | arXiv:2507.18053 abstract |
| Example #6 multimodal "10 to 100 times" text cost | corrected | Anthropic Vision docs + pricing/energy studies (no 10-100x source) |
| Scenario #9 "$0.001 -> $0.50 -> hundreds of dollars" single session | corrected | Arithmetic check (~$25/session; "hundreds" reattributed to aggregate) |

## Reviewed and not changed

- No PDF-only artifacts. Steve flagged no PDF spacing or hyperlink defect for LLM06, and `edit-result.json` `pdf_artifacts[]` is empty. The markdown source has normal ASCII spacing after numbered items.

## Style and conformance

- Block-spacing normalized: every `####` subsection now has a blank line after the heading and no leading body indent, matching LLM04 house style; `revised-substance.md` is byte-identical to `revised.md` (single substantive commit).
- `conformance.sh` on `revised.md`: **HARD PASS, exit 0** (Tier-1: 0 em dashes, 0 semicolons, 0 invisible characters, 0 blank-line-after-heading, 0 consecutive-blank-lines after the fix).
- AI-writing tells removed: 1 prose semicolon, 3 "Furthermore," 1 "crucial," 2 softened importance-inflation phrases. Tier-2 AI-vocabulary is now **0 hits** in `revised.md`.
- Advisory count: **1 Tier-2 advisory hit** (citation closure). It is a `references.md`-side matter and is **deferred to the reference-sync worklist**, not gated at the entry (an entry PR cannot edit `references.md`, F6).
- Appendix Exception preserved: the entry carries no `### References` and no `### Related Frameworks and Taxonomies` section. References live in `references.md` (APA-7, inline author-date); framework mappings live in `Appendix_A_Related_Framework_Mappings.md`. Their absence is by design, not a defect.

## Residual risk

None open at the entry level. The following are **deferred to the reference-sync worklist** (`references.md`-owned, F6), each with a reason:

- **The 1 Tier-2 citation-closure advisory = 11 uncited LLM06 references** (Akkus 2024, Anthropic n.d., Awan 2023, DeepLearning.AI 2023, Dong B. 2026, Jiang W. 2024, moohax & monoxgas 2023, Nevo 2024, Radosevich & Halloran 2025, Sev 2023, Taori 2023). Decision: cite-or-prune each. Reason for deferral: an entry PR cannot edit `references.md`; the orphan set is identical before and after this edit, so no deletion introduced a new orphan.
- **Two cite-candidate orphans** the owner may prefer to cite rather than prune: Dong, B. et al. (2026) "Clawdrain" (tool-calling-chain token exhaustion, fits example #8 / Scenario #7) and Radosevich & Halloran (2025) "MCP safety audit" (fits the MCP amplification point). Reason for deferral: adding named sources is exposition beyond this review's minimal-implementation scope; the reference owner decides.
- **Verifier `must_fix`: empty** (`verify-result.json` `must_fix: []`). No verifier-mandated reference-sync item exists for LLM06; nothing further to defer.

## Reviewers

@virtualsteve-star @Sahil-Mehta881 @saikishu (@rocklambros authored; mention only, not requested)
