### PR TITLE
LLM07:2026 Misinformation: RC1 review fixes

### DIFF
--- a/2026/final/LLM07_Misinformation.md
+++ b/2026/final/LLM07_Misinformation.md
@@ -8,7 +8,7 @@ In modern systems, model outputs drive tool calls, generate code, infer system s
 
 In agentic systems, misinformation often manifests as incorrect state, reasoning, or evidence that is consumed by downstream components, leading directly to unintended actions.
 
-Misinformation can arise from hallucination, incomplete or stale context, weak grounding, ambiguous prompts, biased or corrupted data, misleading summaries, or unvalidated tool outputs. It can also be deliberately induced by attackers. Where the root cause is prompt injection, poisoning, or supply chain compromise, those risks should be referenced separately. This entry focuses on the resulting failure mode: a false representation that drives a harmful decision or action.
+Misinformation can arise from hallucination, incomplete or stale context, weak grounding, ambiguous prompts, biased or corrupted data, misleading summaries, or unvalidated tool outputs. It can also be deliberately induced by attackers. Where the root cause is prompt injection, poisoning, or supply chain compromise, those risks should be referenced separately. The execution and handling of unsafe generated code is covered by LLM10:2026 Improper Output Handling, and the registration of hallucinated package names as a supply-chain vector is covered by LLM04:2026 Supply Chain. This entry focuses on the resulting failure mode: a false representation that drives a harmful decision or action.
 
 Overreliance remains a key factor. Humans and systems often treat fluent, confident, or well-structured outputs as authoritative. In agentic architectures, this overreliance is frequently embedded in system design.
 

--- a/2026/final/LLM07_Misinformation.md
+++ b/2026/final/LLM07_Misinformation.md
@@ -16,7 +16,7 @@ Overreliance remains a key factor. Humans and systems often treat fluent, confid
 
 1. Unsupported or False Decision Support: Incorrect or unsupported information influences business, legal, healthcare, financial, or operational decisions.
 2. Incorrect State Inference in Workflows: An LLM infers that a condition has been met when it has not, triggering unintended actions.
-3. Unsafe Code and Dependency Generation: The model generates insecure code, hallucinated packages, or invalid configurations (Spracklen et al., 2025).
+3. Incorrect or Fabricated Code and Dependencies: The model produces incorrect code recommendations or references non-existent (hallucinated) packages (Spracklen et al., 2025).
 4. Misleading Summaries and Critical Omissions: Summaries omit key constraints, exceptions, timestamps, or risks.
 5. Adversarially Induced Misinformation: Attackers craft inputs that cause false claims or omission of critical facts.
 6. Cross-Agent Misinformation Propagation: Incorrect outputs propagate across agents and workflows.
@@ -26,7 +26,7 @@ Overreliance remains a key factor. Humans and systems often treat fluent, confid
 
 1. Ground Claims Before Action: Require outputs to be grounded in authoritative and current sources.
 2. Implement Claim–Check–Act Patterns: Separate generation from execution and verify claims before acting.
-3. Validate Tool Calls Semantically: Ensure alignment with intent, permissions, and real-world state.
+3. Validate Tool Calls: Check arguments, authorization, preconditions, and current state before execution.
 4. Use Verification Signals (Not Just Confidence): Incorporate groundedness and consistency checks.
 5. Enforce Runtime Verification for High-Impact Actions: Introduce approval workflows and system checks.
 6. Detect and Prevent Omission Failures: Require structured outputs with mandatory fields.
@@ -37,23 +37,30 @@ Overreliance remains a key factor. Humans and systems often treat fluent, confid
 
 ### Example Attack Scenarios
 
-Scenario #1: Hallucinated Dependency Supply Chain Attack  
-Attackers publish malicious packages under hallucinated names used by coding assistants, leading to compromise (Spracklen et al., 2025).
+#### Scenario #1: Hallucinated Dependency Recommendation
 
-Scenario #2: Incorrect Policy Decision by Agent  
-An agent incorrectly approves a refund or exception, resulting in financial loss.
+A coding assistant recommends a plausible but non-existent package, which an attacker has pre-registered under the hallucinated name, so a developer who trusts the suggestion installs attacker-controlled code (Spracklen et al., 2025).
 
-Scenario #3: Omission in Safety-Critical Summary  
-A summary omits a critical constraint, leading to harmful action.
+#### Scenario #2: Incorrect Policy Decision by Agent
 
-Scenario #4: Adversarially Induced False Reasoning  
-Misleading inputs cause incorrect recommendations that are accepted.
+A customer-service agent misreads a policy and approves a refund that violates the terms, resulting in financial loss.
 
-Scenario #5: False Alert Triggers Automated Response  
-A system incorrectly detects an attack and disrupts operations.
+#### Scenario #3: Omission in Safety-Critical Summary
 
-Scenario #6: Cross-Agent Trust Failure  
-One agent passes incorrect state that another trusts, leading to high-impact failure.
+A clinical summary omits a drug contraindication, and a clinician acts on the incomplete recommendation.
 
-Scenario #7: Fabricated Task Completion  
-An agent falsely reports task completion, leading to downstream failure.
+#### Scenario #4: Adversarially Induced False Reasoning
+
+An attacker seeds a support forum with false remediation steps that a troubleshooting agent retrieves and repeats as a trusted recommendation.
+
+#### Scenario #5: False Alert Triggers Automated Response
+
+A security agent misclassifies normal traffic as an intrusion and automatically blocks a production network segment, causing an outage.
+
+#### Scenario #6: Cross-Agent Trust Failure
+
+A retrieval agent reports a customer as identity-verified when it is not, and a downstream payment agent trusts that state and releases funds.
+
+#### Scenario #7: Fabricated Task Completion
+
+An agent reports that a nightly database backup completed when it never ran, and a later restore fails because no backup exists.

--- a/2026/final/LLM07_Misinformation.md
+++ b/2026/final/LLM07_Misinformation.md
@@ -2,7 +2,7 @@
 
 ### Description
 
-Misinformation occurs when an LLM or LLM-enabled application produces incorrect, incomplete, unsupported, or misleading information that appears credible enough to influence a human decision, an automated workflow, or an agent action. The core risk is not simply that the model is wrong, but that the incorrect output is trusted and acted upon.
+Misinformation occurs when an LLM or LLM-enabled application produces incorrect, incomplete, unsupported, or misleading information that appears credible enough to influence a human decision, an automated workflow, or an agent action. The core risk is that the incorrect output is trusted and acted upon.
 
 In modern systems, model outputs drive tool calls, generate code, infer system state, authorize actions, and coordinate across agents. This makes misinformation a system-level failure that can lead to financial loss, security incidents, safety risks, or operational disruption.
 
@@ -25,13 +25,13 @@ Overreliance remains a key factor. Humans and systems often treat fluent, confid
 ### Prevention and Mitigation Strategies
 
 1. Ground Claims Before Action: Require outputs to be grounded in authoritative and current sources.
-2. Implement Claim–Check–Act Patterns: Separate generation from execution and verify claims before acting.
+2. Implement Claim-Check-Act Patterns: Separate generation from execution and verify claims before acting.
 3. Validate Tool Calls: Check arguments, authorization, preconditions, and current state before execution.
 4. Use Verification Signals (Not Just Confidence): Incorporate groundedness and consistency checks.
 5. Enforce Runtime Verification for High-Impact Actions: Introduce approval workflows and system checks.
 6. Detect and Prevent Omission Failures: Require structured outputs with mandatory fields.
 7. Limit Blast Radius: Apply least privilege, sandboxing, and rate limits.
-8. Monitor and Test for Misinformation: Log claims, evidence, and outcomes; test adversarial scenarios.
+8. Monitor and Test for Misinformation: Log claims, evidence, and outcomes, and test adversarial scenarios.
 9. Calibrate Human and System Trust: Distinguish verified facts from assumptions.
 10. Adversarial Evaluation and Continuous Testing: Regularly test workflows against misleading scenarios.
 


### PR DESCRIPTION
# LLM07: apply RC1 review (Misinformation)

Branch: `review/rc1/llm07-misinformation` · Base: `release-candidate-1` · Net line delta: **+7**

## Summary

Applies Steve Wilson's RC1 review to `2026/final/LLM07_Misinformation.md`, plus a premortem pass and a house-style + AI-writing-tell cleanup. The entry keeps its intended brevity while making each sentence carry more weight: one vague mitigation is made concrete, two items are narrowed to LLM07's ownership boundary (the model's incorrect recommendation, not downstream execution/handling), the seven attack scenarios are each made concrete in one sentence and normalized to H4, and the remaining AI-tell and typography items are cleaned. Conformance is Tier-1 HARD PASS (exit 0). No quantitative claim in the body; the single external citation (Spracklen et al., 2025) is verified against a canonical primary source.

## Sources of findings

* **Steve Wilson's LLM07 review** (`.review/steve_review.md`, items 1-5): technical precision, scope, editorial, definite correction, tightening.
* **Premortem** (entry-as-manuscript, Round 2 citation/source fidelity): attempted orphan on the risk-#3 narrowing (REFUTED — LLM10 covers it) and an antithesis-regression check (REFUTED — the change removes a tell).
* **Conformance `.review/conformance.sh`**: Tier-1 (semicolon) and Tier-2 (negative parallelism) hits.
* **Spec Decision 3**: scenario format normalization to H4.
* **Typography sweep**: non-ASCII en dash normalization.

## Changes

| # | Severity | Source | Category | Location | Change | Evidence |
|---|---|---|---|---|---|---|
| 1 | technical precision | Steve #1 | FIX | Prevention item 3 (orig line 29) | "Validate Tool Calls Semantically: Ensure alignment with intent, permissions, and real-world state." → "Validate Tool Calls: Check arguments, authorization, preconditions, and current state before execution." | Reproduces line 29; Steve's concrete replacement, drops "semantically". |
| 2 | scope | Steve #2 | SCOPE | Common Example 3 (orig line 19) | "Unsafe Code and Dependency Generation: ...insecure code, hallucinated packages, or invalid configurations" → "Incorrect or Fabricated Code and Dependencies: ...incorrect code recommendations or references non-existent (hallucinated) packages". Dropped "insecure code" + "invalid configurations". | Reproduces line 19; execution/handling owned by LLM10, coverage-checked (SD1). |
| 3 | editorial | Steve #3 | FIX | Scenarios #2-#7 (orig lines 43-59) | Each scenario made concrete in one sentence (clinical contraindication, refund-terms violation, seeded false remediation, blocked production segment, cross-agent false verification, fabricated backup completion). No numbers/cites invented. | Reproduces Scenario #3 line 47; Steve #3 one-sentence concreteness. |
| 4 | definite correction (non-reproducing) | Steve #4 | PDF | Prevention item 10 (orig line 36) | No fix — markdown already uses a standard ASCII space after "10.". | Line 36 bytes `31 30 2e 20`; no hidden char. PDF-extraction artifact. |
| 5 | scope/tightening | Steve #5 | SCOPE | Scenario #1 (orig lines 40-41) | "Hallucinated Dependency Supply Chain Attack" → "Hallucinated Dependency Recommendation", reframed to LLM07's misinformation stage. One package-hallucination example kept at two altitudes. | Reproduces lines 19, 40-41; slopsquatting infra → LLM04, coverage-checked (SD2). |
| 6 | structural | spec Decision 3 | FIX | Scenarios, all 7 (orig lines 40-59) | Labeled "Scenario #N: Title" lines (trailing double-space breaks) → "#### Scenario #N: Title" H4 headings; 7 hard breaks removed. Uniform with LLM10. | Orig titles carried 2 trailing spaces; Decision 3 mandates uniform H4. |
| 7 | hard-gate (Tier-1) | conformance.sh Tier-1 | FIX | Prevention item 8 (orig line 34) | ";" → ", and": "Log claims, evidence, and outcomes, and test adversarial scenarios." | Red run HARD FAIL 1, line 34; only HARD hit. |
| 8 | tell-sweep (Tier-2 advisory) | conformance.sh Tier-2 | FIX | Description para 1 (orig line 5) | "The core risk is not simply that the model is wrong, but that the incorrect output is trusted and acted upon." → "The core risk is that the incorrect output is trusted and acted upon." | Red advisory negative-parallelism, line 5; cleared in green run. |
| 9 | style-sweep | typography sweep | FIX | Prevention item 2 (orig line 28) | "Claim-Check-Act" (two U+2013) → ASCII hyphens. | Whole-file non-ASCII scan: only two U+2013 on line 28; meaning-preserving. |

## Verification log

| Claim | Status | Source opened |
|---|---|---|
| Spracklen et al. (2025): code-generating LLMs recommend non-existent (hallucinated) packages that attackers can pre-register/exploit (Common Example #3, Scenario #1) | verified [V] | arXiv:2406.10279 (canonical preprint of USENIX Security 2025); authors/title match `references.md`; states >=5.2%/21.7% hallucination rates, 205,474 unique hallucinated names, "package confusion attack" framing. Verify pass re-opened the live USENIX PDF (HTTP 200): six-author list + venue "34th USENIX Security Symposium, August 2025" match. Content match confirmed. |

No numbers, percentages, or CVEs otherwise appear in the body; this is the entry's only external factual claim.

## Reviewed and not changed (PDF artifacts)

* **Steve #4 — missing space after "10." in the adversarial-evaluation item.** Markdown line 36 is "10." + a normal ASCII space (U+0020); a whole-file scan found no hidden/nonbreaking character. This is a PDF text-extraction artifact, not present in the source markdown. No fix applied.

## Style and conformance

* **Conformance `.review/conformance.sh revised.md`: Tier-1 HARD PASS (exit 0).** Red run had one Tier-1 HARD hit (semicolon, line 34) and one Tier-2 advisory (negative parallelism, line 5); both fixed (changes #7, #8). Green run: exit 0, advisory cleared.
* **Tells removed:** 1 semicolon (Tier-1), 1 antithesis/negative-parallelism clause (Tier-2), 2 en dashes → ASCII hyphens, 7 trailing double-space hard breaks (scenario normalization). Sentence-initial conjunctions and AI-vocabulary sweep: 0 hits.
* **Tier-2 advisory count deferred to reference-sync:** 5 citation-closure advisory hits (uncited references: BBC News n.d., NIST AI 600-1 2024, OpenAI 2025, OWASP GenAI 2025, Zou W. 2025) and 1 link-liveness advisory (BBC News n.d. now HTTP 404) are deferred to the reference-sync worklist — an entry PR cannot edit `references.md`. See Residual risk.
* **Appendix Exception (not a defect):** the entry carries no `### References` and no `### Related Frameworks and Taxonomies` section by design; references live in `references.md`, framework mappings in Appendix A. Their absence is correct, not flagged.

## Residual risk

All open items are reference-sync concerns; the LLM07 entry PR cannot edit `references.md`, so each is deferred to `review/rc1/references-appendix-sync` with the conservative default applied (leave `references.md` unchanged, do not pad the LLM07 body).

* **RR1 — five uncited references in `references.md` "## LLM07:"** (BBC News n.d., NIST AI 600-1 2024, OpenAI 2025, OWASP GenAI 2025 LLM09:2025, Zou W. et al. 2025 PoisonedRAG). Deferred to reference-sync — reason: adding inline cites would pad the entry with exposition it does not need; none are required for a finding to close. Default: `references.md` unchanged.
* **RR2 — Spracklen year discrepancy** (LLM07 = 2025 USENIX; LLM04 = 2024 arXiv, same work). Deferred to reference-sync — reason: coupled change touching the LLM04 body + `references.md`, must merge sync-first (spec section 8). Default: LLM07 unchanged (already the 2025 target).
* **RR3 — BBC News (n.d.) LLM07 reference is a bare/generic URL and now returns HTTP 404** (dead link found in the verify pass). Deferred to reference-sync — reason: `references.md` rides the sync PR, not the entry PR; likely resolution is removal. Default: unchanged, flagged.
* **PoisonedRAG (Zou W. 2025) URL standardization** across LLM01/LLM07/LLM09 (two distinct USENIX URLs, spec section 8 MUST-fix). Deferred to reference-sync — reason: cross-entry coupling; standardize to the canonical USENIX record. Zou W. 2025 is also one of the RR1 uncited references.

## Reviewers

* @virtualsteve-star (LLM07 lead / CODEOWNERS for `2026/final`; also entry lead).

Author @rocklambros is dropped from the review request and kept as an @-mention per spec section 11.
