### PR TITLE
LLM08:2026 Hidden Context Exposure: RC1 review fixes

### DIFF
--- a/2026/final/LLM08_HiddenContextExposure.md
+++ b/2026/final/LLM08_HiddenContextExposure.md
@@ -6,11 +6,11 @@ Hidden Context Exposure is the unauthorized extraction, inference, or reconstruc
 
 In an LLM application, hidden context typically includes the system prompt, developer instructions, retrieved policy text (from RAG knowledge bases, configuration stores, or user-profile services), the schemas of tools and functions the application exposes to the model, and other rules, directives, and materials the application assembles into the model's context window. The common thread is that this hidden context is not intended to be visible to end users but is accessible to the model.
 
-Practitioners should design under the assumption that hidden context is discoverable and that any contents of the context should not be considered a secret. Application developers should ensure that its full disclosure would have no or minimal direct security impact. Sensitive data such as credentials, connection strings, and tokens should not be embedded in it, nor should hidden context be solely relied upon as a security boundary for authorization, privilege separation, policy enforcement, or content filtering.
+Practitioners should design under the assumption that hidden context is discoverable and that any contents of the context should not be considered a secret. Application developers should ensure that disclosure of hidden context has little or no direct security impact. Sensitive data such as credentials, connection strings, and tokens should not be embedded in it, nor should hidden context be solely relied upon as a security boundary for authorization, privilege separation, policy enforcement, or content filtering.
 
 Severity tracks what is placed in hidden context and how the application relies on it. Findings range from **informational** (no secrets, no security-relevant logic, no reliance on confidentiality) through **medium** (internal rules, filtering criteria, role descriptions, or workflow logic that meaningfully aids an attacker but does not gate critical decisions) to **high** (embedded credentials or tokens, or reliance on hidden-context secrecy for authorization or content policy) and **critical** (where disclosure chains to remote code execution, broad data exfiltration, or privilege escalation in a connected system).
 
-While Hidden Context Exposure introduces risks on its own, it also frequently amplifies risks in adjacent categories: disclosed rules or logic enable more targeted prompt injection (LLM01); embedded credentials constitute sensitive information disclosure (LLM02); revealed tool permissions and schemas expand the surface for excessive agency (LLM03); leaked output-formatting rules can facilitate improper output handling (LLM10).
+While Hidden Context Exposure introduces risks on its own, it also frequently amplifies risks in adjacent categories: disclosed rules or logic enable more targeted prompt injection (LLM01:2026); embedded credentials constitute sensitive information disclosure (LLM02:2026); revealed tool permissions and schemas expand the surface for excessive agency (LLM03:2026); leaked output-formatting rules can facilitate improper output handling (LLM10:2026).
 
 In summary, LLM08 covers the foundational risk that hidden LLM control context is exposed, inferred, or reconstructed in a way that materially increases attacker capability. LLM08 does not cover:
 
@@ -34,7 +34,7 @@ System prompts can define the conditions under which a model should refuse or fi
 
 #### 4. Disclosure of Permissions and User Roles
 
-Instruction context could include directives or information related to authorization and permissions. For example, a tool description provided through an internal-facing MCP server may indicate that a user must have the developer role in order to use it, or that a user with a certain role can access a list of documents to search with RAG. The disclosure of such information could invite other types of probing through directed conversation and prompt injection (LLM01) and could potentially reveal additional sensitive information (LLM02).
+Instruction context could include directives or information related to authorization and permissions. For example, a tool description provided through an internal-facing MCP server may indicate that a user must have the developer role in order to use it, or that a user with a certain role can access a list of documents to search with RAG. The disclosure of such information could invite other types of probing through directed conversation and prompt injection (LLM01:2026) and could potentially reveal additional sensitive information (LLM02:2026).
 
 #### 5. Exposure of Output Structure and Formatting Rules
 
@@ -44,7 +44,7 @@ System prompts frequently define how responses should be structured, including r
 
 #### 1. Do Not Put Sensitive Data in Hidden Context
 
-Do not embed any sensitive information (e.g., API keys, auth keys, database names, user roles, permission structure of the application) directly in the system prompts or hidden context. Assume all context available to the LLM could also be available to users. Instead, externalize such information to the systems that the model does not directly access and avoid letting the model handle sensitive data itself.
+Do not embed credentials, secrets, or security-critical configuration directly in the system prompts or hidden context. Assume all context available to the LLM could also be available to users. Instead, externalize such information to the systems that the model does not directly access and avoid letting the model handle sensitive data itself.
 
 #### 2. Use Deterministic Methods and Guardrails for Validation and Behavior Control
 
@@ -52,11 +52,7 @@ Because LLMs can be vulnerable to attacks such as prompt injection, hidden conte
 
 #### 3. Enforce Authorization and Access Control Independently from the LLM
 
-Critical controls such as privilege separation, authorization bounds checks, and similar must not be delegated to the LLM, whether through the system prompt or another mechanism. These controls should be enforced in a deterministic and auditable manner, which LLMs are not well suited to provide. In cases where an agent is performing tasks, if those tasks require different levels of access, then multiple agents should be used, each configured with the least privileges needed to perform the desired tasks.
-
-#### 4. Adopt Context Obfuscation
-
-For context the application must process, avoid relying on common system prompt templates, section names, or predictable instruction structures. Varying how instructions are named, written and structured so that they are less directly identifiable or reusable could provide an additional layer of complexity for attackers. Mitigations such as these should only be used as a minor supporting measure, not a primary defense. The best defense is to avoid extraneous and sensitive context and assume all context is discoverable.
+Critical controls such as privilege separation, authorization bounds checks, and similar must not be delegated to the LLM, whether through the system prompt or another mechanism. These controls should be enforced in a deterministic and auditable manner, which LLMs are not well suited to provide. Where tasks require different levels of access, separate them by authorization context and grant each only the privileges it requires.
 
 ### Example Attack Scenarios
 
@@ -70,4 +66,4 @@ An attacker extracts the hidden context that contains the tool list and paramete
 
 #### Scenario #3
 
-An LLM has a system prompt prohibiting the generation of offensive content, external links, and code execution. An attacker extracts this system prompt and then uses a prompt injection attack to bypass these instructions, facilitating a remote code execution attack.
+An LLM has a system prompt prohibiting the generation of offensive content, external links, and code execution. An attacker extracts this system prompt and uses the disclosed restrictions to craft a prompt injection attack that bypasses them.

--- a/2026/final/LLM08_HiddenContextExposure.md
+++ b/2026/final/LLM08_HiddenContextExposure.md
@@ -10,7 +10,12 @@ Practitioners should design under the assumption that hidden context is discover
 
 Severity tracks what is placed in hidden context and how the application relies on it. Findings range from **informational** (no secrets, no security-relevant logic, no reliance on confidentiality) through **medium** (internal rules, filtering criteria, role descriptions, or workflow logic that meaningfully aids an attacker but does not gate critical decisions) to **high** (embedded credentials or tokens, or reliance on hidden-context secrecy for authorization or content policy) and **critical** (where disclosure chains to remote code execution, broad data exfiltration, or privilege escalation in a connected system).
 
-While Hidden Context Exposure introduces risks on its own, it also frequently amplifies risks in adjacent categories: disclosed rules or logic enable more targeted prompt injection (LLM01:2026); embedded credentials constitute sensitive information disclosure (LLM02:2026); revealed tool permissions and schemas expand the surface for excessive agency (LLM03:2026); leaked output-formatting rules can facilitate improper output handling (LLM10:2026).
+While Hidden Context Exposure introduces risks on its own, it also frequently amplifies risks in adjacent categories:
+
+* Disclosed rules or logic enable more targeted prompt injection (LLM01:2026).
+* Embedded credentials constitute sensitive information disclosure (LLM02:2026).
+* Revealed tool permissions and schemas expand the surface for excessive agency (LLM03:2026).
+* Leaked output-formatting rules can facilitate improper output handling (LLM10:2026).
 
 In summary, LLM08 covers the foundational risk that hidden LLM control context is exposed, inferred, or reconstructed in a way that materially increases attacker capability. LLM08 does not cover:
 
@@ -48,7 +53,7 @@ Do not embed credentials, secrets, or security-critical configuration directly i
 
 #### 2. Use Deterministic Methods and Guardrails for Validation and Behavior Control
 
-Because LLMs can be vulnerable to attacks such as prompt injection, hidden context should not be relied on as the primary mechanism for controlling model behavior. Specialized fine tuning or further training of a model may decrease the risk of disclosure, but it is not a consistent guarantee and may have other unintended consequences. Instead, enforce critical behaviors through independent and deterministic systems outside the model. For example, harmful content detection and prevention should be handled by external safeguards rather than by instructions embedded in hidden context.
+Because LLMs can be vulnerable to attacks such as prompt injection, hidden context should not be relied on as the primary mechanism for controlling model behavior. Specialized fine-tuning or further training of a model may decrease the risk of disclosure, though it provides no consistent guarantee and may have other unintended consequences. Enforce critical behaviors through independent and deterministic systems outside the model. For example, harmful content detection and prevention should be handled by external safeguards rather than by instructions embedded in hidden context.
 
 #### 3. Enforce Authorization and Access Control Independently from the LLM
 


### PR DESCRIPTION
## Summary

Applies the RC1 review to LLM08:2026 Hidden Context Exposure (a copyedit-priority entry): fixes an unclear pronoun, deletes the weak "Context Obfuscation" security-by-obscurity mitigation, replaces the over-prescriptive "use multiple agents" wording, tightens the sensitive-items list to secrets, removes an RCE overclaim from Scenario #3, and clears the AI-writing tells. Net +1 line.

## Sources of findings

- Steve Wilson, "Editorial and Technical Review of the 2026 OWASP Top 10 for LLM Applications RC1", section LLM08
- Editorial review, premortem, and bottom-up claim extraction against this entry, 2026-07-13

## Changes

| # | Severity | Source | Category | Location | Change | Evidence |
|---|---|---|---|---|---|---|
| 1 | Med | Wilson | Grammar | Description | pronoun fix ("its full disclosure" → explicit) | Steve #1 |
| 2 | High | Wilson | Weak control | Prevention #4 | deleted "Adopt Context Obfuscation" (security-by-obscurity) | Steve #2 |
| 3 | Med | Wilson | Precision | Prevention #3 | "use multiple agents" → authorization-context wording | Steve #3 |
| 4 | Med | Wilson | Precision | Prevention #1 | sensitive-items list → credentials/secrets/security-critical config | Steve #4 |
| 5 | Med | Wilson | Accuracy | Scenario #3 | removed RCE overclaim; disclosure improves the injection | Steve #5 |
| 6 | — | Style | Tells | Description | 3 prose semicolons → `*` bulleted list (cross-refs kept) | HARD conformance |
| 7 | — | Style | Tells | Prevention #2 | antithesis "is not X. Instead Y" rewritten | AI-tell |
| 8 | — | Style | Consistency | Prevention #2 | "fine tuning" → "fine-tuning" | house style |

## Verification log

No quantitative/attributed claims in the entry body; Scenario #3 RCE overclaim corrected by technical reasoning. Nothing parked. (See verification.md.)

## Reviewed and not changed

- Steve reviewed a generated PDF; no PDF-only artifacts flagged for LLM08.

## Style and conformance

AI-writing tells removed (3 prose semicolons, 1 antithesis, term hyphenation). `conformance.sh`: **HARD PASS, exit 0**. 9 advisory citation-closure hits (all uncited references), triaged and deferred to the reference-sync worklist. References and framework mappings remain out of the entry body by design.

## Residual risk

None open at the entry level. The 9 uncited LLM08 references are deferred to the reference-sync PR (bind-or-prune), owned by the entry leads.

## Reviewers

@virtualsteve-star @atleung @zoh-labs @vingiarrusso (@rocklambros authored)
